### PR TITLE
allow prometheus to scrape metrics

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	defaultAddress        = ":8080"
-	defaultMetricsAddress = ":8000"
+	defaultAddress        = ":8443"
+	defaultMetricsAddress = ":8080"
 )
 
 type Config struct {

--- a/config/config.go
+++ b/config/config.go
@@ -12,11 +12,13 @@ import (
 )
 
 const (
-	defaultAddress = ":8080"
+	defaultAddress        = ":8080"
+	defaultMetricsAddress = ":8000"
 )
 
 type Config struct {
 	Address           string
+	MetricsAddress    string
 	AvailabilityZones string
 	CertFile          string
 	Logger            micrologger.Logger
@@ -64,6 +66,7 @@ func Parse() (Config, error) {
 	}
 
 	kingpin.Flag("address", "The address to listen on").Default(defaultAddress).StringVar(&config.Address)
+	kingpin.Flag("metrics-address", "The metrics address for Prometheus").Default(defaultMetricsAddress).StringVar(&config.MetricsAddress)
 	kingpin.Flag("availability-zones", "List of AWS availability zones.").Required().StringVar(&config.AvailabilityZones)
 	kingpin.Flag("tls-cert-file", "File containing the certificate for HTTPS").Required().StringVar(&config.CertFile)
 	kingpin.Flag("tls-key-file", "File containing the private key for HTTPS").Required().StringVar(&config.KeyFile)

--- a/helm/aws-admission-controller/templates/deployment.yaml
+++ b/helm/aws-admission-controller/templates/deployment.yaml
@@ -41,7 +41,6 @@ spec:
             - --tls-cert-file=/certs/ca.crt
             - --tls-key-file=/certs/tls.key
             - --availability-zones=$(DEFAULT_AWS_AZS)
-            - --
           volumeMounts:
           - name: {{ include "name" . }}-certificates
             mountPath: "/certs"

--- a/helm/aws-admission-controller/templates/deployment.yaml
+++ b/helm/aws-admission-controller/templates/deployment.yaml
@@ -45,22 +45,22 @@ spec:
           - name: {{ include "name" . }}-certificates
             mountPath: "/certs"
           ports:
-          - containerPort: 8080
+          - containerPort: 8443
             name: webhook
-          - containerPort: 8000
+          - containerPort: 8080
             name: metrics
           livenessProbe:
             httpGet:
               path: /healthz
               scheme: HTTPS
-              port: 8080
+              port: 8443
             initialDelaySeconds: 30
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
               path: /healthz
               scheme: HTTPS
-              port: 8080
+              port: 8443
             initialDelaySeconds: 30
             timeoutSeconds: 10
           resources:

--- a/helm/aws-admission-controller/templates/deployment.yaml
+++ b/helm/aws-admission-controller/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
             - --tls-cert-file=/certs/ca.crt
             - --tls-key-file=/certs/tls.key
             - --availability-zones=$(DEFAULT_AWS_AZS)
+            - --
           volumeMounts:
           - name: {{ include "name" . }}-certificates
             mountPath: "/certs"

--- a/helm/aws-admission-controller/templates/deployment.yaml
+++ b/helm/aws-admission-controller/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
             mountPath: "/certs"
           ports:
           - containerPort: 8080
+            name: webhook
+          - containerPort: 8000
+            name: metrics
           livenessProbe:
             httpGet:
               path: /healthz

--- a/helm/aws-admission-controller/templates/networkpolicy.yaml
+++ b/helm/aws-admission-controller/templates/networkpolicy.yaml
@@ -15,6 +15,8 @@ spec:
   - ports:
     - port: 443
       protocol: TCP
+    - port: 8443
+      protocol: TCP
     - port: 8080
       protocol: TCP
   policyTypes:

--- a/helm/aws-admission-controller/templates/service.yaml
+++ b/helm/aws-admission-controller/templates/service.yaml
@@ -8,10 +8,10 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/path: "/metrics"
-    prometheus.io/port: "8000"
+    prometheus.io/port: "8080"
 spec:
   ports:
   - port: 443
-    targetPort: 8080
+    targetPort: 8443
   selector:
     {{- include "labels.selector" . | nindent 4 }}

--- a/helm/aws-admission-controller/templates/service.yaml
+++ b/helm/aws-admission-controller/templates/service.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
   annotations:
     prometheus.io/scrape: "true"
+    prometheus.io/path: "/metrics",
+    prometheus.io/port: "8000",
 spec:
   ports:
   - port: 443

--- a/helm/aws-admission-controller/templates/service.yaml
+++ b/helm/aws-admission-controller/templates/service.yaml
@@ -7,8 +7,8 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/path: "/metrics",
-    prometheus.io/port: "8000",
+    prometheus.io/path: "/metrics"
+    prometheus.io/port: "8000"
 spec:
   ports:
   - port: 443

--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ func serveTLS(config config.Config, handler http.Handler) {
 
 func serveMetrics(config config.Config, handler http.Handler) {
 	server := &http.Server{
-		Addr:    config.Address,
+		Addr:    config.MetricsAddress,
 		Handler: handler,
 	}
 

--- a/main.go
+++ b/main.go
@@ -60,10 +60,13 @@ func main() {
 	handler.Handle("/validate/awscontrolplane", validator.Handler(awscontrolplaneValidator))
 	handler.Handle("/validate/awsmachinedeployment", validator.Handler(awsmachinedeploymentValidator))
 
-	handler.Handle("/metrics", promhttp.Handler())
 	handler.HandleFunc("/healthz", healthCheck)
 
-	serve(config, handler)
+	metrics := http.NewServeMux()
+	metrics.Handle("/metrics", promhttp.Handler())
+
+	serveTLS(config, handler)
+	serveMetrics(config, metrics)
 }
 
 func healthCheck(writer http.ResponseWriter, request *http.Request) {
@@ -74,7 +77,7 @@ func healthCheck(writer http.ResponseWriter, request *http.Request) {
 	}
 }
 
-func serve(config config.Config, handler http.Handler) {
+func serveTLS(config config.Config, handler http.Handler) {
 	server := &http.Server{
 		Addr:    config.Address,
 		Handler: handler,
@@ -91,6 +94,30 @@ func serve(config config.Config, handler http.Handler) {
 	}()
 
 	err := server.ListenAndServeTLS(config.CertFile, config.KeyFile)
+	if err != nil {
+		if err != http.ErrServerClosed {
+			panic(microerror.JSON(err))
+		}
+	}
+}
+
+func serveMetrics(config config.Config, handler http.Handler) {
+	server := &http.Server{
+		Addr:    config.Address,
+		Handler: handler,
+	}
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM)
+	go func() {
+		<-sig
+		err := server.Shutdown(context.Background())
+		if err != nil {
+			panic(microerror.JSON(err))
+		}
+	}()
+
+	err := server.ListenAndServe()
 	if err != nil {
 		if err != http.ErrServerClosed {
 			panic(microerror.JSON(err))

--- a/main.go
+++ b/main.go
@@ -65,8 +65,8 @@ func main() {
 	metrics := http.NewServeMux()
 	metrics.Handle("/metrics", promhttp.Handler())
 
+	go serveMetrics(config, metrics)
 	serveTLS(config, handler)
-	serveMetrics(config, metrics)
 }
 
 func healthCheck(writer http.ResponseWriter, request *http.Request) {


### PR DESCRIPTION
currently prometheus cant scrape metrics because it expects non-TLS endpoint

![image](https://user-images.githubusercontent.com/1936982/95077839-70508e80-0714-11eb-9620-7f3681a9672f.png)
