### PR TITLE
Validation of Networkpools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - aws-admission-controller metrics
 - Validation for control-plane label
 - Validation for machine-deployment label
+- Validation for NetworkPools
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Validating Webhook:
 - In a `AWSControlPlane` resource, it validates the Control Plane ID is matching against `G8sControlPlane` resource.
 - In a `AWSMachineDeployment` resource, it validates the Machine Deployment ID is matching against `MachineDeployment` resource.
 
+- In a `NetworkPool` resource, it validates the .Spec.CIDRBlock from other NetworkPools and also checks if there's overlapping from Docker CIDR, Kubernetes cluster IP range or tenant cluster CIDR.
+
 The certificates for the webhook are created with CertManager and injected through the CA Injector.
 
 ## Ownership

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	MetricsAddress    string
 	AvailabilityZones string
 	CertFile          string
+	IPAMNetworkCIDR   string
 	Logger            micrologger.Logger
 	K8sClient         k8sclient.Interface
 	KeyFile           string
@@ -68,6 +69,7 @@ func Parse() (Config, error) {
 	kingpin.Flag("address", "The address to listen on").Default(defaultAddress).StringVar(&config.Address)
 	kingpin.Flag("metrics-address", "The metrics address for Prometheus").Default(defaultMetricsAddress).StringVar(&config.MetricsAddress)
 	kingpin.Flag("availability-zones", "List of AWS availability zones.").Required().StringVar(&config.AvailabilityZones)
+	kingpin.Flag("ipam-network-cidr", "Default CIDR from tenant cluster.").Required().StringVar(&config.IPAMNetworkCIDR)
 	kingpin.Flag("tls-cert-file", "File containing the certificate for HTTPS").Required().StringVar(&config.CertFile)
 	kingpin.Flag("tls-key-file", "File containing the private key for HTTPS").Required().StringVar(&config.KeyFile)
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,14 +17,16 @@ const (
 )
 
 type Config struct {
-	Address           string
-	MetricsAddress    string
-	AvailabilityZones string
-	CertFile          string
-	IPAMNetworkCIDR   string
-	Logger            micrologger.Logger
-	K8sClient         k8sclient.Interface
-	KeyFile           string
+	Address                  string
+	MetricsAddress           string
+	AvailabilityZones        string
+	CertFile                 string
+	DockerCIDR               string
+	IPAMNetworkCIDR          string
+	KubernetesClusterIPRange string
+	Logger                   micrologger.Logger
+	K8sClient                k8sclient.Interface
+	KeyFile                  string
 }
 
 func Parse() (Config, error) {
@@ -67,9 +69,11 @@ func Parse() (Config, error) {
 	}
 
 	kingpin.Flag("address", "The address to listen on").Default(defaultAddress).StringVar(&config.Address)
+	kingpin.Flag("availability-zones", "List of AWS availability zones").Required().StringVar(&config.AvailabilityZones)
+	kingpin.Flag("docker-cidr", "Default CIDR from Docker").Required().StringVar(&config.DockerCIDR)
+	kingpin.Flag("ipam-network-cidr", "Default CIDR from tenant cluster").Required().StringVar(&config.IPAMNetworkCIDR)
+	kingpin.Flag("kubernetes-cluster-ip-range", "Default CIDR from Kubernetes").Required().StringVar(&config.KubernetesClusterIPRange)
 	kingpin.Flag("metrics-address", "The metrics address for Prometheus").Default(defaultMetricsAddress).StringVar(&config.MetricsAddress)
-	kingpin.Flag("availability-zones", "List of AWS availability zones.").Required().StringVar(&config.AvailabilityZones)
-	kingpin.Flag("ipam-network-cidr", "Default CIDR from tenant cluster.").Required().StringVar(&config.IPAMNetworkCIDR)
 	kingpin.Flag("tls-cert-file", "File containing the certificate for HTTPS").Required().StringVar(&config.CertFile)
 	kingpin.Flag("tls-key-file", "File containing the private key for HTTPS").Required().StringVar(&config.KeyFile)
 

--- a/helm/aws-admission-controller/ci/default-values.yaml
+++ b/helm/aws-admission-controller/ci/default-values.yaml
@@ -11,7 +11,7 @@ Installation:
     Docker:
       CIDR: "172.18.224.1/19"
      IPAM:
-      NetworkCIDR: 10.35.0.0/17
+      NetworkCIDR: "10.35.0.0/17"
     Kubernetes:
       API:
-        ClusterIPRange: '172.18.192.0/20'
+        ClusterIPRange: "172.18.192.0/20"

--- a/helm/aws-admission-controller/ci/default-values.yaml
+++ b/helm/aws-admission-controller/ci/default-values.yaml
@@ -8,10 +8,11 @@ Installation:
           - eu-central-1a
           - eu-central-1b
           - eu-central-1c
-    Docker:
-      CIDR: "172.18.224.1/19"
-    IPAM:
-      NetworkCIDR: "10.35.0.0/17"
-    Kubernetes:
-      API:
-        ClusterIPRange: "172.18.192.0/20"
+    Guest:
+      Docker:
+        CIDR: "172.18.224.1/19"
+      IPAM:
+        NetworkCIDR: "10.35.0.0/17"
+      Kubernetes:
+        API:
+          ClusterIPRange: "172.18.192.0/20"

--- a/helm/aws-admission-controller/ci/default-values.yaml
+++ b/helm/aws-admission-controller/ci/default-values.yaml
@@ -8,3 +8,10 @@ Installation:
           - eu-central-1a
           - eu-central-1b
           - eu-central-1c
+    Docker:
+      CIDR: "172.18.224.1/19"
+     IPAM:
+      NetworkCIDR: 10.35.0.0/17
+    Kubernetes:
+      API:
+        ClusterIPRange: '172.18.192.0/20'

--- a/helm/aws-admission-controller/ci/default-values.yaml
+++ b/helm/aws-admission-controller/ci/default-values.yaml
@@ -10,7 +10,7 @@ Installation:
           - eu-central-1c
     Docker:
       CIDR: "172.18.224.1/19"
-     IPAM:
+    IPAM:
       NetworkCIDR: "10.35.0.0/17"
     Kubernetes:
       API:

--- a/helm/aws-admission-controller/templates/deployment.yaml
+++ b/helm/aws-admission-controller/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
             - name: DEFAULT_IPAM_NETWORKCIDR
               value: {{ .Values.Installation.V1.Guest.IPAM.NetworkCIDR }}
             - name: DEFAULT_KUBERNETES_CLUSTER_IP_RANGE
-              value: {{ .Values.Installation.V1.Guest.Kubernetes.ClusterIPRange }}
+              value: {{ .Values.Installation.V1.Guest.Kubernetes.API.ClusterIPRange }}
           args:
             - ./aws-admission-controller
             - --availability-zones=$(DEFAULT_AWS_AZS)

--- a/helm/aws-admission-controller/templates/deployment.yaml
+++ b/helm/aws-admission-controller/templates/deployment.yaml
@@ -36,11 +36,14 @@ spec:
           env:
             - name: DEFAULT_AWS_AZS
               value: {{ join "," .Values.Installation.V1.Provider.AWS.AvailabilityZones }}
+            - name: DEFAULT_IPAM_NETWORKCIDR
+              value: {{ .Values.Installation.V1.Guest.IPAM.NetworkCIDR }}
           args:
             - ./aws-admission-controller
             - --tls-cert-file=/certs/ca.crt
             - --tls-key-file=/certs/tls.key
             - --availability-zones=$(DEFAULT_AWS_AZS)
+            - --ipam-network-cidr=$(DEFAULT_IPAM_NETWORKCIDR)
           volumeMounts:
           - name: {{ include "name" . }}-certificates
             mountPath: "/certs"

--- a/helm/aws-admission-controller/templates/deployment.yaml
+++ b/helm/aws-admission-controller/templates/deployment.yaml
@@ -36,14 +36,20 @@ spec:
           env:
             - name: DEFAULT_AWS_AZS
               value: {{ join "," .Values.Installation.V1.Provider.AWS.AvailabilityZones }}
+            - name: DEFAULT_DOCKER_CIDR
+              value: {{ .Values.Installation.V1.Guest.Docker.CIDR }}
             - name: DEFAULT_IPAM_NETWORKCIDR
               value: {{ .Values.Installation.V1.Guest.IPAM.NetworkCIDR }}
+            - name: DEFAULT_KUBERNETES_CLUSTER_IP_RANGE
+              value: {{ .Values.Installation.V1.Guest.Kubernetes.ClusterIPRange }}
           args:
             - ./aws-admission-controller
+            - --availability-zones=$(DEFAULT_AWS_AZS)
+            - --docker-cidr=$(DEFAULT_DOCKER_CIDR)
+            - --ipam-network-cidr=$(DEFAULT_IPAM_NETWORKCIDR)
+            - --kubernetes-cluster-ip-range=$(DEFAULT_KUBERNETES_CLUSTER_IP_RANGE)
             - --tls-cert-file=/certs/ca.crt
             - --tls-key-file=/certs/tls.key
-            - --availability-zones=$(DEFAULT_AWS_AZS)
-            - --ipam-network-cidr=$(DEFAULT_IPAM_NETWORKCIDR)
           volumeMounts:
           - name: {{ include "name" . }}-certificates
             mountPath: "/certs"

--- a/helm/aws-admission-controller/templates/rbac.yaml
+++ b/helm/aws-admission-controller/templates/rbac.yaml
@@ -16,6 +16,8 @@ rules:
       - awsmachinedeployments/status
       - g8scontrolplanes
       - g8scontrolplanes/status
+      - networkpools
+      - networkpools/status
     verbs:
       - "*"
   - apiGroups:

--- a/helm/aws-admission-controller/templates/webhook.yaml
+++ b/helm/aws-admission-controller/templates/webhook.yaml
@@ -109,3 +109,21 @@ webhooks:
         operations:
           - CREATE
           - UPDATE
+  - name: networkpools.{{ include "resource.default.name" . }}.giantswarm.io
+    failurePolicy: Ignore
+    sideEffects: NoneOnDryRun
+    clientConfig:
+      service:
+        name: {{ include "resource.default.name" . }}
+        namespace: {{ include "resource.default.namespace" . }}
+        path: /validate/networkpool
+      caBundle: Cg==
+    rules:
+      - apiGroups: ["infrastructure.giantswarm.io"]
+        resources:
+          - "networkpools"
+        apiVersions:
+          - "v1alpha2"
+        operations:
+          - CREATE
+          - UPDATE

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/giantswarm/aws-admission-controller/pkg/aws/awscontrolplane"
 	"github.com/giantswarm/aws-admission-controller/pkg/aws/awsmachinedeployment"
 	"github.com/giantswarm/aws-admission-controller/pkg/aws/g8scontrolplane"
+	"github.com/giantswarm/aws-admission-controller/pkg/aws/networkpool"
 	"github.com/giantswarm/aws-admission-controller/pkg/mutator"
 	"github.com/giantswarm/aws-admission-controller/pkg/validator"
 )
@@ -52,6 +53,11 @@ func main() {
 		panic(microerror.JSON(err))
 	}
 
+	networkPoolValidator, err := networkpool.NewValidator(config)
+	if err != nil {
+		panic(microerror.JSON(err))
+	}
+
 	// Here we register our endpoints.
 	handler := http.NewServeMux()
 	handler.Handle("/mutate/awsmachinedeployment", mutator.Handler(awsmachinedeploymentMutator))
@@ -59,6 +65,7 @@ func main() {
 	handler.Handle("/mutate/g8scontrolplane", mutator.Handler(g8scontrolplaneMutator))
 	handler.Handle("/validate/awscontrolplane", validator.Handler(awscontrolplaneValidator))
 	handler.Handle("/validate/awsmachinedeployment", validator.Handler(awsmachinedeploymentValidator))
+	handler.Handle("/validate/networkpool", validator.Handler(networkPoolValidator))
 
 	handler.HandleFunc("/healthz", healthCheck)
 

--- a/pkg/aws/networkpool/error.go
+++ b/pkg/aws/networkpool/error.go
@@ -1,0 +1,59 @@
+package networkpool
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
+var intersectFailedError = &microerror.Error{
+	Kind: "intersectFailedError",
+}
+
+// IsIntersectFailed asserts intersectFailedError.
+func IsIntersectFailed(err error) bool {
+	return microerror.Cause(err) == intersectFailedError
+}
+
+var notAllowedError = &microerror.Error{
+	Kind: "notAllowedError",
+}
+
+// IsNotAllowed asserts notAllowedError.
+func IsNotAllowed(err error) bool {
+	return microerror.Cause(err) == notAllowedError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var parsingFailedError = &microerror.Error{
+	Kind: "parsingFailedError",
+}
+
+// IsParsingFailed asserts parsingFailedError.
+func IsParsingFailed(err error) bool {
+	return microerror.Cause(err) == parsingFailedError
+}

--- a/pkg/aws/networkpool/validate_networkpool.go
+++ b/pkg/aws/networkpool/validate_networkpool.go
@@ -104,6 +104,10 @@ func (v *Validator) networkPoolOverlapping(np infrastructurev1alpha2.NetworkPool
 
 	// append all CIDRs from existing NetworkPools
 	for _, networkPool := range networkPoolList.Items {
+		// we do not want to add the same networkpool when updating, e.g. when extending the IP range
+		if networkPool.Name == np.Name && networkPool.Namespace == np.Namespace {
+			continue
+		}
 		networkCIDRs = append(networkCIDRs, networkPool.Spec.CIDRBlock)
 	}
 

--- a/pkg/aws/networkpool/validate_networkpool.go
+++ b/pkg/aws/networkpool/validate_networkpool.go
@@ -63,7 +63,6 @@ func (v *Validator) Validate(request *v1beta1.AdmissionRequest) (bool, error) {
 	allowed, err := v.networkPoolOverlapping(networkPool)
 	if err != nil {
 		return false, microerror.Mask(err)
-
 	}
 
 	return allowed, nil

--- a/pkg/aws/networkpool/validate_networkpool.go
+++ b/pkg/aws/networkpool/validate_networkpool.go
@@ -123,7 +123,7 @@ func (v *Validator) networkPoolOverlapping(np infrastructurev1alpha2.NetworkPool
 		}
 		// in case of overlapping network ranges we do not allow creating this NetworkPool
 		if intersect(customNet, net) {
-			return false, microerror.Maskf(intersectFailedError, fmt.Sprintf("network pool %s intersect with %s", customNet.String(), net.String()))
+			return false, microerror.Maskf(intersectFailedError, fmt.Sprintf("network pool %s intersect with an existing CIDR %s", customNet.String(), net.String()))
 		}
 
 	}

--- a/pkg/aws/networkpool/validate_networkpool.go
+++ b/pkg/aws/networkpool/validate_networkpool.go
@@ -60,7 +60,7 @@ func (v *Validator) Validate(request *v1beta1.AdmissionRequest) (bool, error) {
 	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, &networkPool); err != nil {
 		return false, microerror.Maskf(parsingFailedError, "unable to parse networkpool: %v", err)
 	}
-	allowed, err := v.networkPoolOverlapping(networkPool)
+	allowed, err := v.networkPoolAllowed(networkPool)
 	if err != nil {
 		return false, microerror.Mask(err)
 	}
@@ -68,7 +68,7 @@ func (v *Validator) Validate(request *v1beta1.AdmissionRequest) (bool, error) {
 	return allowed, nil
 }
 
-func (v *Validator) networkPoolOverlapping(np infrastructurev1alpha2.NetworkPool) (bool, error) {
+func (v *Validator) networkPoolAllowed(np infrastructurev1alpha2.NetworkPool) (bool, error) {
 	var err error
 	var fetch func() error
 	var networkCIDRs []string

--- a/pkg/aws/networkpool/validate_networkpool.go
+++ b/pkg/aws/networkpool/validate_networkpool.go
@@ -105,7 +105,6 @@ func (v *Validator) networkPoolOverlapping(np infrastructurev1alpha2.NetworkPool
 
 	// append all CIDRs from existing NetworkPools
 	for _, networkPool := range networkPoolList.Items {
-		fmt.Println(networkPool)
 		networkCIDRs = append(networkCIDRs, networkPool.Spec.CIDRBlock)
 	}
 

--- a/pkg/aws/networkpool/validate_networkpool.go
+++ b/pkg/aws/networkpool/validate_networkpool.go
@@ -1,0 +1,145 @@
+package networkpool
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/v2/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/backoff"
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/api/admission/v1beta1"
+
+	"github.com/giantswarm/aws-admission-controller/config"
+	"github.com/giantswarm/aws-admission-controller/pkg/validator"
+)
+
+type Validator struct {
+	ipamNetworkCIDR string
+	k8sClient       k8sclient.Interface
+	logger          micrologger.Logger
+}
+
+func NewValidator(config config.Config) (*Validator, error) {
+	if config.IPAMNetworkCIDR == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.IPAMNetworkCIDR must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	validator := &Validator{
+		ipamNetworkCIDR: config.IPAMNetworkCIDR,
+		k8sClient:       config.K8sClient,
+		logger:          config.Logger,
+	}
+
+	return validator, nil
+}
+
+func (v *Validator) Validate(request *v1beta1.AdmissionRequest) (bool, error) {
+	var networkPool infrastructurev1alpha2.NetworkPool
+	var allowed bool
+
+	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, &networkPool); err != nil {
+		return false, microerror.Maskf(parsingFailedError, "unable to parse networkpool: %v", err)
+	}
+	allowed, err := v.networkPoolOverlapping(networkPool)
+	if err != nil {
+		return false, microerror.Mask(err)
+
+	}
+
+	return allowed, nil
+}
+
+func (v *Validator) networkPoolOverlapping(networkPool infrastructurev1alpha2.NetworkPool) (bool, error) {
+	var err error
+	var fetch func() error
+	var networkCIDRs []string
+	var networkPoolList infrastructurev1alpha2.NetworkPoolList
+
+	// Fetch all NetworkPools.
+	{
+		v.Log("level", "debug", "message", "Fetching all NetworkPools")
+		fetch = func() error {
+			ctx := context.Background()
+
+			err = v.k8sClient.CtrlClient().List(
+				ctx,
+				&networkPoolList,
+			)
+			if err != nil {
+				return microerror.Maskf(notFoundError, "failed to fetch NetworkPools: %v", err)
+			}
+
+			return nil
+		}
+	}
+
+	{
+		b := backoff.NewMaxRetries(3, 1*time.Second)
+		err = backoff.Retry(fetch, b)
+		if IsNotFound(err) {
+			v.Log("level", "debug", "message", fmt.Sprintf("No NetworkPool could be found: %v", err))
+		} else if err != nil {
+			return false, microerror.Mask(err)
+		}
+	}
+
+	// append all CIDRs from existing NetworkPools
+	for _, networkPool := range networkPoolList.Items {
+		networkCIDRs = append(networkCIDRs, networkPool.Spec.CIDRBlock)
+	}
+
+	// append tenant network CIDR
+	networkCIDRs = append(networkCIDRs, v.ipamNetworkCIDR)
+
+	// parse CIDRBlock from NetworkPool
+	customNet, err := mustParseCIDR(networkPool.Spec.CIDRBlock)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	for _, cidr := range networkCIDRs {
+		net, err := mustParseCIDR(cidr)
+		if err != nil {
+			return false, microerror.Mask(err)
+		}
+		// in case of overlapping network ranges we do not allow creating this NetworkPool
+		if intersect(customNet, net) {
+			return false, microerror.Maskf(intersectFailedError, fmt.Sprintf("network pool %s intersect with %s", customNet.String(), net.String()))
+		}
+
+	}
+
+	return true, nil
+}
+
+func (v *Validator) Log(keyVals ...interface{}) {
+	v.logger.Log(keyVals...)
+}
+
+func (v *Validator) Resource() string {
+	return "networkpool"
+}
+
+func mustParseCIDR(cidr string) (*net.IPNet, error) {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return ipNet, nil
+}
+
+// intersect checks if network ranges overlap
+func intersect(n1, n2 *net.IPNet) bool {
+	return n2.Contains(n1.IP) || n1.Contains(n2.IP)
+}

--- a/pkg/aws/networkpool/validate_networkpool_test.go
+++ b/pkg/aws/networkpool/validate_networkpool_test.go
@@ -1,0 +1,101 @@
+package networkpool
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-admission-controller/pkg/unittest"
+)
+
+func TestNetworkPool(t *testing.T) {
+	testCases := []struct {
+		name              string
+		ctx               context.Context
+		customNetworkCIDR string
+		networkPoolCIDRs  []string
+		tenantNetworkCIDR string
+
+		allowed bool
+	}{
+		{
+			// No intersection
+			name:              "case 0",
+			ctx:               context.Background(),
+			customNetworkCIDR: "192.168.178.0/24",
+			networkPoolCIDRs:  []string{"192.168.179.0/24", "172.16.0.0/16"},
+			tenantNetworkCIDR: "10.0.0.0/16",
+
+			allowed: true,
+		},
+		{
+			// Intersection
+			name:              "case 1",
+			ctx:               context.Background(),
+			tenantNetworkCIDR: "10.0.0.0/16",
+			networkPoolCIDRs:  []string{"172.16.1.0/20"},
+			customNetworkCIDR: "172.16.0.0/16",
+
+			allowed: false,
+		},
+		{
+			// Intersection
+			name:              "case 2",
+			ctx:               context.Background(),
+			tenantNetworkCIDR: "10.0.0.0/8",
+			networkPoolCIDRs:  []string{"172.16.0.0/16"},
+			customNetworkCIDR: "10.0.16.0/16",
+
+			allowed: false,
+		},
+		{
+			// Intersection
+			name:              "case 3",
+			ctx:               context.Background(),
+			tenantNetworkCIDR: "10.0.0.0/24",
+			networkPoolCIDRs:  []string{"10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"},
+			customNetworkCIDR: "10.0.255.0/16",
+
+			allowed: false,
+		},
+		{
+			// No intersection
+			name:              "case 4",
+			ctx:               context.Background(),
+			customNetworkCIDR: "172.16.0.0/16",
+			tenantNetworkCIDR: "10.0.0.0/16",
+
+			allowed: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+
+			fakeK8sClient := unittest.FakeK8sClient()
+			validate := &Validator{
+				ipamNetworkCIDR: tc.tenantNetworkCIDR,
+				k8sClient:       fakeK8sClient,
+				logger:          microloggertest.New(),
+			}
+
+			// create NetworkPools
+			for _, networkPoolCIDR := range tc.networkPoolCIDRs {
+				fakeK8sClient.CtrlClient().Create(tc.ctx, unittest.DefaultNetworkPool(networkPoolCIDR))
+			}
+
+			// simulate a admission request for NetworkPool creation
+			request, err := unittest.DefaultAdmissionRequestNetworkPool(tc.customNetworkCIDR)
+			if err != nil {
+				t.Fatal(err)
+			}
+			allowed, err := validate.Validate(&request)
+			if tc.allowed != allowed {
+				t.Fatalf("expected %v to not to differ from %v: %v", allowed, tc.allowed, err)
+			}
+		})
+	}
+}

--- a/pkg/aws/networkpool/validate_networkpool_test.go
+++ b/pkg/aws/networkpool/validate_networkpool_test.go
@@ -98,7 +98,10 @@ func TestNetworkPool(t *testing.T) {
 
 			// create NetworkPools
 			for _, networkPoolCIDR := range tc.networkPoolCIDRs {
-				fakeK8sClient.CtrlClient().Create(tc.ctx, unittest.DefaultNetworkPool(networkPoolCIDR))
+				err = fakeK8sClient.CtrlClient().Create(tc.ctx, unittest.DefaultNetworkPool(networkPoolCIDR))
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 
 			// simulate a admission request for NetworkPool creation

--- a/pkg/unittest/default_network_pool.go
+++ b/pkg/unittest/default_network_pool.go
@@ -46,7 +46,7 @@ func DefaultNetworkPool(cidrBlock string) *v1alpha2.NetworkPool {
 			Name:      id.Generate(),
 			Namespace: id.Generate(),
 			Labels: map[string]string{
-				"": "",
+				"giantswarm.io/organization": "giantswarm",
 			},
 		},
 		Spec: v1alpha2.NetworkPoolSpec{

--- a/pkg/unittest/default_network_pool.go
+++ b/pkg/unittest/default_network_pool.go
@@ -1,0 +1,57 @@
+package unittest
+
+import (
+	"encoding/json"
+
+	"github.com/giantswarm/apiextensions/v2/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/apiextensions/v2/pkg/id"
+	"github.com/giantswarm/microerror"
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func DefaultAdmissionRequestNetworkPool(cidrBlock string) (v1beta1.AdmissionRequest, error) {
+	byt, err := json.Marshal(DefaultNetworkPool(cidrBlock))
+	if err != nil {
+		return v1beta1.AdmissionRequest{}, microerror.Mask(err)
+	}
+
+	req := v1beta1.AdmissionRequest{
+		Kind: metav1.GroupVersionKind{
+			Version: "infrastructure.giantswarm.io/v1alpha2",
+			Kind:    "NetworkPool",
+		},
+		Resource: metav1.GroupVersionResource{
+			Version:  "infrastructure.giantswarm.io/v1alpha2",
+			Resource: "networkpools",
+		},
+		Operation: v1beta1.Create,
+		Object: runtime.RawExtension{
+			Raw:    byt,
+			Object: nil,
+		},
+	}
+	return req, nil
+}
+
+func DefaultNetworkPool(cidrBlock string) *v1alpha2.NetworkPool {
+	cr := &v1alpha2.NetworkPool{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "NetworkPool",
+			APIVersion: "infrastructure.giantswarm.io/v1alpha2",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      id.Generate(),
+			Namespace: id.Generate(),
+			Labels: map[string]string{
+				"": "",
+			},
+		},
+		Spec: v1alpha2.NetworkPoolSpec{
+			CIDRBlock: cidrBlock,
+		},
+	}
+	return cr
+}


### PR DESCRIPTION
Ref.: https://github.com/giantswarm/giantswarm/issues/13462
Check in case of overlapping network ranges, this should not pass our admission-controller

When creating / updating a `networkpool` we want to ensure we do not collide with other network ranges, aws-admission-controller should not allow this.

Ensure validation runs against:

- [x] NetworkPools in all namespaces
- [x] Docker CIDR
- [x] Kubernetes service CIDR
- [x] Default network CIDR
- [x] Updating networkpool in case of extending the IP range should be allowed
