### PR TITLE
Use cert-manager v1 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use cert-manager v1 API
+
 ## [2.1.0] - 2020-10-29
 
 ### Added

--- a/helm/aws-admission-controller/templates/certificate.yaml
+++ b/helm/aws-admission-controller/templates/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "resource.default.name"  . }}-certificates


### PR DESCRIPTION
CPs have cert-manager-app-2.3.0 (cert-manager v1.0.2), so GA APIs can be used.