### PR TITLE
add defaulting for awscluster description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added defaulting for the Cluster description in the `AWSCluster` CR
+
 ## [2.1.0] - 2020-10-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Giant Swarm Control Plane admission controller that implements the following rul
 
 Mutating Webhook:
 
+- In an `AWSCluster` resource, the Description is defaulted if it is not set. 
 - In an `AWSCluster` resource, the Pod CIDR is defaulted if it is not set. 
 
 - In a `G8sControlPlane` resource, when the `.spec.replicas` is changed from 1 to 3, the Availability Zones of the according `AWSControlPlane` will be defaulted if needed.

--- a/pkg/aws/common.go
+++ b/pkg/aws/common.go
@@ -5,6 +5,9 @@ import (
 )
 
 const (
+	// DefaultClusterDescription is the default name for a cluster
+	DefaultClusterDescription = "Unnamed cluster"
+
 	// DefaultMasterReplicas is the default number of master node replicas
 	DefaultMasterReplicas = 3
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14025
`Spec.Cluster.Description` : default to `Unnamed cluster`