### PR TITLE
adding defaulting for awscluster dns domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added defaulting for the Cluster description in the `AWSCluster` CR
+- Added defaulting for the Cluster DNS domain in the `AWSCluster` CR
 
 ## [2.1.0] - 2020-10-29
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Giant Swarm Control Plane admission controller that implements the following rul
 Mutating Webhook:
 
 - In an `AWSCluster` resource, the Description is defaulted if it is not set. 
+- In an `AWSCluster` resource, the DNS Domain is defaulted if it is not set. 
 - In an `AWSCluster` resource, the Pod CIDR is defaulted if it is not set. 
 
 - In a `G8sControlPlane` resource, when the `.spec.replicas` is changed from 1 to 3, the Availability Zones of the according `AWSControlPlane` will be defaulted if needed.

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	AvailabilityZones        string
 	CertFile                 string
 	DockerCIDR               string
+	Endpoint                 string
 	IPAMNetworkCIDR          string
 	KubernetesClusterIPRange string
 	MasterInstanceTypes      string
@@ -74,6 +75,7 @@ func Parse() (Config, error) {
 	kingpin.Flag("address", "The address to listen on").Default(defaultAddress).StringVar(&config.Address)
 	kingpin.Flag("availability-zones", "List of AWS availability zones").Required().StringVar(&config.AvailabilityZones)
 	kingpin.Flag("docker-cidr", "Default CIDR from Docker").Required().StringVar(&config.DockerCIDR)
+	kingpin.Flag("endpoint", "Default kubernetes endpoint").Required().StringVar(&config.Endpoint)
 	kingpin.Flag("ipam-network-cidr", "Default CIDR from tenant cluster").Required().StringVar(&config.IPAMNetworkCIDR)
 	kingpin.Flag("kubernetes-cluster-ip-range", "Default CIDR from Kubernetes").Required().StringVar(&config.KubernetesClusterIPRange)
 	kingpin.Flag("master-instance-types", "List of AWS master instance types").Required().StringVar(&config.MasterInstanceTypes)

--- a/helm/aws-admission-controller/ci/default-values.yaml
+++ b/helm/aws-admission-controller/ci/default-values.yaml
@@ -48,3 +48,4 @@ Installation:
       Kubernetes:
         API:
           ClusterIPRange: "172.18.192.0/20"
+          EndpointBase: k8s.gauss.eu-west-1.aws.gigantic.io

--- a/helm/aws-admission-controller/templates/deployment.yaml
+++ b/helm/aws-admission-controller/templates/deployment.yaml
@@ -42,6 +42,8 @@ spec:
               value: {{ .Values.Installation.V1.Guest.IPAM.NetworkCIDR }}
             - name: DEFAULT_KUBERNETES_CLUSTER_IP_RANGE
               value: {{ .Values.Installation.V1.Guest.Kubernetes.API.ClusterIPRange }}
+            - name: DEFAULT_KUBERNETES_ENDPOINT              
+              value: {{ .Values.Installation.V1.Guest.Kubernetes.API.EndpointBase }}
             - name: DEFAULT_AWS_INSTANCE_TYPES
               value: {{ join "," .Values.Installation.V1.Provider.AWS.EC2.Instance.Allowed }}
             - name: DEFAULT_AWS_POD_CIDR
@@ -52,6 +54,7 @@ spec:
             - ./aws-admission-controller
             - --availability-zones=$(DEFAULT_AWS_AZS)
             - --docker-cidr=$(DEFAULT_DOCKER_CIDR)
+            - --endpoint=$(DEFAULT_KUBERNETES_ENDPOINT)
             - --ipam-network-cidr=$(DEFAULT_IPAM_NETWORKCIDR)
             - --kubernetes-cluster-ip-range=$(DEFAULT_KUBERNETES_CLUSTER_IP_RANGE)
             - --master-instance-types=$(DEFAULT_AWS_INSTANCE_TYPES)

--- a/pkg/unittest/default_cluster.go
+++ b/pkg/unittest/default_cluster.go
@@ -11,6 +11,8 @@ import (
 
 const (
 	DefaultPodCIDR = "10.2.0.0/16"
+
+	DefaultClusterDNSDomain = "gauss.eu-west-1.aws.gigantic.io"
 )
 
 func DefaultAWSCluster() infrastructurev1alpha2.AWSCluster {


### PR DESCRIPTION
Towards: giantswarm/giantswarm#14025
`Spec.Cluster.DNS.Domain` : default to value from installation info