### PR TITLE
Roll admission-controller if caBundle has changed

### DIFF
--- a/helm/aws-admission-controller/templates/deployment.yaml
+++ b/helm/aws-admission-controller/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/certs: {{ include (print $.Template.BasePath "/webhookconfiguration.yaml") . | sha256sum }}
         releaseRevision: {{ .Release.Revision | quote }}
       labels:
         {{- include "labels.common" . | nindent 8 }}

--- a/helm/aws-admission-controller/templates/deployment.yaml
+++ b/helm/aws-admission-controller/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/certs: {{ include (print $.Template.BasePath "/webhookconfiguration.yaml") . | sha256sum }}
+        checksum/certs: {{ include (print $.Template.BasePath "/webhook.yaml") . | sha256sum }}
         releaseRevision: {{ .Release.Revision | quote }}
       labels:
         {{- include "labels.common" . | nindent 8 }}


### PR DESCRIPTION
Whenever cert-manager refreshes the certificate we want to ensure we roll the pods.

We want to detect this behaviour in case the cainjector populates new caBundles inside the webhook config.
This is loaded by Kubernetes API to verify the serving cert from the admission-controller.