### PR TITLE
separate fetching of CRs

### DIFF
--- a/pkg/aws/awscontrolplane/mutate_awscontrolplane.go
+++ b/pkg/aws/awscontrolplane/mutate_awscontrolplane.go
@@ -396,12 +396,3 @@ func releaseVersion(cr *infrastructurev1alpha2.AWSControlPlane) (*semver.Version
 
 	return semver.New(version)
 }
-
-func clusterID(cr *infrastructurev1alpha2.AWSControlPlane) (string, error) {
-	clusterID, ok := cr.Labels[label.Cluster]
-	if !ok {
-		return "", microerror.Maskf(parsingFailedError, "unable to get cluster ID from AWSControlplane %s", cr.Name)
-	}
-
-	return clusterID, nil
-}


### PR DESCRIPTION
Towards: giantswarm/giantswarm#13827
Step 3/4 : Split up the logic for fetching the g8scontrolplane as well as the one for fetching the awscluster for preHA defaulting into separate functions. Next step is to deal with the version labels.