### PR TITLE
default release version in awscontrolplane cr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Default the Release Version Label and refactor the `G8sControlplane` Mutator
+- Default the Release Version Label and refactor the `G8sControlplane` and `AWSControlPlane` Mutators.
 - Default the Release Version Label in the `AWSCluster`, `MachineDeployment` and `AWSMachineDeployment` CRs based on the `Cluster`CR
 
 ## [2.2.2] - 2020-11-10

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Mutating Webhook:
   - For pre-HA versions, replicas is always set to 1 for a single master cluster.
 - In a `G8sControlPlane` resource, the infrastructure reference will be set to point to the matching `AWSControlPlane` resource if it already exists.
 
+- In an `AWSControlplane` resource, the Release Version is defaulted based on the `Cluster` CR if it is not set. 
 - In an `AWSControlPlane` resource, the Availability Zones will be defaulted if they are `nil`. 
   - For HA-Versions, in case the matching `G8sControlPlane` already exists, the number of AZs is determined by the number of `replicas` defined there. 
     In case no such `G8sControlPlane` exists, the default number of AZs is assigned. 

--- a/pkg/aws/awscontrolplane/mutate_awscontrolplane.go
+++ b/pkg/aws/awscontrolplane/mutate_awscontrolplane.go
@@ -85,7 +85,7 @@ func (m *Mutator) MutateCreate(request *admissionv1.AdmissionRequest) ([]mutator
 	}
 	releaseVersion, err := releaseVersion(awsControlPlaneCR, patch)
 	if err != nil {
-		return nil, microerror.Maskf(parsingFailedError, "unable to parse release version from G8sControlPlane")
+		return nil, microerror.Maskf(parsingFailedError, "unable to parse release version from AWSControlPlane")
 	}
 	result = append(result, patch...)
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14025
Step 4/4 : Default the version label of the `awscontrolplane` CR to the one set in the `cluster` CR.