### PR TITLE
Default AWSCluster Master attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Default the Master attributes in the `AWSCluster` Mutator for pre-HA versions.
 - Default the Release Version Label and refactor the `G8sControlplane` and `AWSControlPlane` Mutators.
 - Default the Release Version Label in the `AWSCluster`, `MachineDeployment` and `AWSMachineDeployment` CRs based on the `Cluster`CR
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Mutating Webhook:
 - In an `AWSCluster` resource, the Description is defaulted if it is not set. 
 - In an `AWSCluster` resource, the DNS Domain is defaulted if it is not set. 
 - In an `AWSCluster` resource, the Pod CIDR is defaulted if it is not set. 
+- In an `AWSCluster` resource, in a pre-HA version, the Master attribute is defaulted if it is not set.
 
 - In an `G8sControlplane` resource, the Release Version is defaulted based on the `Cluster` CR if it is not set. 
 - In a `G8sControlPlane` resource, when the `.spec.replicas` is changed from 1 to 3, the Availability Zones of the according `AWSControlPlane` will be defaulted if needed.

--- a/pkg/aws/error.go
+++ b/pkg/aws/error.go
@@ -21,3 +21,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var parsingFailedError = &microerror.Error{
+	Kind: "parsingFailedError",
+}
+
+// IsParsingFailed asserts parsingFailedError.
+func IsParsingFailed(err error) bool {
+	return microerror.Cause(err) == parsingFailedError
+}

--- a/pkg/unittest/default_cluster.go
+++ b/pkg/unittest/default_cluster.go
@@ -11,10 +11,12 @@ import (
 )
 
 const (
-	DefaultPodCIDR          = "10.2.0.0/16"
-	DefaultClusterDNSDomain = "gauss.eu-west-1.aws.gigantic.io"
-	DefaultClusterRegion    = "eu-west-1"
-	DefaultReleaseVersion   = "100.0.0"
+	DefaultPodCIDR                = "10.2.0.0/16"
+	DefaultClusterDNSDomain       = "gauss.eu-west-1.aws.gigantic.io"
+	DefaultClusterRegion          = "eu-west-1"
+	DefaultReleaseVersion         = "100.0.0"
+	DefaultMasterInstanceType     = "m4.xlarge"
+	DefaultMasterAvailabilityZone = "eu-central-1b"
 )
 
 func DefaultAWSCluster() infrastructurev1alpha2.AWSCluster {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14025
Since we are opening the possibility of the release version label not being set, the defaulting for the `Master` attribute in pre-HA versions will not work anymore in OPA.
This PR adds that functionality to the admission-controller