### PR TITLE
defaulting for component versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Default the AWS Operator Version Label in `AWSControlplane`, `AWSMachinedeployment` Mutators and add generic label defaulting from AWSCluster CR.
 - Default the Cluster Operator Version Label in `G8sControlplane`, `Machinedeployment` Mutators and add generic label defaulting from cluster CR.
 - Default the Master attributes in the `AWSCluster` Mutator for pre-HA versions.
 - Default the Release Version Label and refactor the `G8sControlplane` and `AWSControlPlane` Mutators.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Default the Cluster Operator Version Label in `G8sControlplane`, `Machinedeployment` Mutators and add generic label defaulting from cluster CR.
 - Default the Master attributes in the `AWSCluster` Mutator for pre-HA versions.
 - Default the Release Version Label and refactor the `G8sControlplane` and `AWSControlPlane` Mutators.
 - Default the Release Version Label in the `AWSCluster`, `MachineDeployment` and `AWSMachineDeployment` CRs based on the `Cluster`CR

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Mutating Webhook:
   - For pre-HA versions, replicas is always set to 1 for a single master cluster.
 - In a `G8sControlPlane` resource, the infrastructure reference will be set to point to the matching `AWSControlPlane` resource if it already exists.
 
+- In an `AWSControlplane` resource, the AWS Operator Version is defaulted based on the `AWSCluster` CR if it is not set. 
 - In an `AWSControlplane` resource, the Release Version is defaulted based on the `Cluster` CR if it is not set. 
 - In an `AWSControlPlane` resource, the Availability Zones will be defaulted if they are `nil`. 
   - For HA-Versions, in case the matching `G8sControlPlane` already exists, the number of AZs is determined by the number of `replicas` defined there. 
@@ -33,6 +34,7 @@ Mutating Webhook:
   - For Pre-HA-Versions, in case the matching `AWSCluster` already exists, the Instance Type is taken from there. 
 - On creation of an `AWSControlPlane` resource, the infrastructure reference of the according `G8sControlPlane` will be set if needed.
 
+- In an `AWSMachinedeployment` resource, the AWS Operator Version is defaulted based on the `AWSCluster` CR if it is not set. 
 - When a new `AWSMachineDeployment` is created, details are logged.
 - In an `AWSMachinedeployment` resource, the Release Version is defaulted based on the `Cluster` CR if it is not set. 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Mutating Webhook:
 - In an `AWSCluster` resource, the Pod CIDR is defaulted if it is not set. 
 - In an `AWSCluster` resource, in a pre-HA version, the Master attribute is defaulted if it is not set.
 
-- In an `G8sControlplane` resource, the Release Version is defaulted based on the `Cluster` CR if it is not set. 
+- In a `G8sControlplane` resource, the Cluster Operator Version is defaulted based on the `Cluster` CR if it is not set. 
+- In a `G8sControlplane` resource, the Release Version is defaulted based on the `Cluster` CR if it is not set. 
 - In a `G8sControlPlane` resource, when the `.spec.replicas` is changed from 1 to 3, the Availability Zones of the according `AWSControlPlane` will be defaulted if needed.
 - In a `G8sControlPlane` resource, the replicas attribute will be defaulted if it is not defined.
   - For HA-Versions, in case the matching `AWSControlPlane` already exists, the number of AZs determines the value of `replicas`.
@@ -36,6 +37,7 @@ Mutating Webhook:
 - In an `AWSMachinedeployment` resource, the Release Version is defaulted based on the `Cluster` CR if it is not set. 
 
 - In a `Machinedeployment` resource, the Release Version is defaulted based on the `Cluster` CR if it is not set. 
+- In a `Machinedeployment` resource, the Cluster Operator Version is defaulted based on the `Cluster` CR if it is not set. 
 
 Validating Webhook:
 

--- a/pkg/aws/awscontrolplane/mutate_awscontrolplane_AZ_test.go
+++ b/pkg/aws/awscontrolplane/mutate_awscontrolplane_AZ_test.go
@@ -227,9 +227,10 @@ func getAWSControlPlaneRAWByte(currentAvailabilityZone []string, currentInstance
 			Name:      controlPlaneName,
 			Namespace: controlPlaneNameSpace,
 			Labels: map[string]string{
-				"giantswarm.io/cluster":         clusterName,
-				"giantswarm.io/control-plane":   controlPlaneName,
-				"release.giantswarm.io/version": release,
+				"giantswarm.io/cluster":              clusterName,
+				"giantswarm.io/control-plane":        controlPlaneName,
+				"release.giantswarm.io/version":      release,
+				"aws-operator.giantswarm.io/version": unittest.DefaultAWSOperatorVersion,
 			},
 		},
 		Spec: infrastructurev1alpha2.AWSControlPlaneSpec{

--- a/pkg/aws/common_mutator.go
+++ b/pkg/aws/common_mutator.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -26,49 +27,65 @@ type Mutator struct {
 	Logger    micrologger.Logger
 }
 
-func MutateReleaseVersionLabel(m *Mutator, meta metav1.Object) ([]mutator.PatchOperation, error) {
+func MutateLabelFromCluster(m *Mutator, meta metav1.Object, cluster capiv1alpha2.Cluster, label string) ([]mutator.PatchOperation, error) {
 	var result []mutator.PatchOperation
 
-	if key.Release(meta) != "" {
+	if meta.GetLabels()[label] != "" {
 		return result, nil
 	}
-	// If the release version label is not set, we default it here
-	{
-		// Retrieve the Cluster ID.
-		clusterID := key.Cluster(meta)
-		if clusterID == "" {
-			return nil, microerror.Maskf(invalidConfigError, "Object has no %s label, can't detect release version.", label.Cluster)
-		}
 
-		namespace := meta.GetNamespace()
-		if namespace == "" {
-			namespace = metav1.NamespaceDefault
-		}
-
-		// Retrieve the `Cluster` CR related to this object.
-		cluster := &capiv1alpha2.Cluster{}
-		{
-			err := m.K8sClient.CtrlClient().Get(context.Background(), client.ObjectKey{Name: clusterID, Namespace: namespace}, cluster)
-			if IsNotFound(err) {
-				return nil, microerror.Maskf(notFoundError, "Looking for Cluster named %s but it was not found.", clusterID)
-			} else if err != nil {
-				return nil, microerror.Mask(err)
-			}
-		}
-
-		// Extract release from Cluster.
-		release := key.Release(cluster)
-		if release == "" {
-			return nil, microerror.Maskf(notFoundError, "Cluster %s did not have a release label set.", clusterID)
-		}
-		m.Logger.Log("level", "debug", "message", fmt.Sprintf("Release label is not set and will be defaulted to %s from Cluster %s.",
-			release,
-			cluster.GetName()))
-		patch := mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", EscapeJSONPatchString(label.Release)), release)
-		result = append(result, patch)
+	// Extract release from Cluster.
+	value := cluster.GetLabels()[label]
+	if value == "" {
+		return nil, microerror.Maskf(notFoundError, "Cluster %s did not have the label %s set.", cluster.GetName(), label)
 	}
+	m.Logger.Log("level", "debug", "message", fmt.Sprintf("Label %s is not set and will be defaulted to %s from Cluster %s.",
+		label,
+		value,
+		cluster.GetName()))
+	patch := mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", EscapeJSONPatchString(label)), value)
+	result = append(result, patch)
 
 	return result, nil
+}
+
+func FetchCluster(m *Mutator, meta metav1.Object) (*capiv1alpha2.Cluster, error) {
+	var cluster capiv1alpha2.Cluster
+	var err error
+	var fetch func() error
+
+	namespace := meta.GetNamespace()
+	if namespace == "" {
+		namespace = metav1.NamespaceDefault
+	}
+	// Retrieve the Cluster ID.
+	clusterID := key.Cluster(meta)
+	if clusterID == "" {
+		return nil, microerror.Maskf(invalidConfigError, "Object has no %s label, can't fetch cluster.", label.Cluster)
+	}
+
+	// Fetch the Cluster CR
+	{
+		m.Logger.Log("level", "debug", "message", fmt.Sprintf("Fetching Cluster %s", clusterID))
+		fetch = func() error {
+			err := m.K8sClient.CtrlClient().Get(context.Background(), client.ObjectKey{Name: clusterID, Namespace: namespace}, &cluster)
+			if IsNotFound(err) {
+				return microerror.Maskf(notFoundError, "Looking for Cluster named %s but it was not found.", clusterID)
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+			return nil
+		}
+	}
+
+	{
+		b := backoff.NewMaxRetries(3, 100*time.Millisecond)
+		err = backoff.Retry(fetch, b)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+	return &cluster, nil
 }
 
 func GetNavailabilityZones(m *Mutator, n int, azs []string) []string {

--- a/pkg/aws/common_test.go
+++ b/pkg/aws/common_test.go
@@ -216,7 +216,7 @@ func TestReleaseVersion(t *testing.T) {
 			var patch []mutator.PatchOperation
 			awscluster := unittest.DefaultAWSCluster()
 			awscluster.SetLabels(map[string]string{label.Release: tc.currentRelease, label.Cluster: unittest.DefaultClusterID})
-			patch, err = MutateReleaseVersionLabel(mutate, awscluster.GetObjectMeta())
+			patch, err = MutateLabelFromCluster(mutate, awscluster.GetObjectMeta(), cluster, label.Release)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/aws/common_test.go
+++ b/pkg/aws/common_test.go
@@ -206,14 +206,9 @@ func TestReleaseVersion(t *testing.T) {
 				K8sClient: fakeK8sClient,
 				Logger:    microloggertest.New(),
 			}
-			// Create Cluster
-			cluster := unittest.DefaultCluster()
-			err = fakeK8sClient.CtrlClient().Create(tc.ctx, &cluster)
-			if err != nil {
-				t.Fatal(err)
-			}
 			// run mutate function to default AWSCluster ReleaseVersion label
 			var patch []mutator.PatchOperation
+			cluster := unittest.DefaultCluster()
 			awscluster := unittest.DefaultAWSCluster()
 			awscluster.SetLabels(map[string]string{label.Release: tc.currentRelease, label.Cluster: unittest.DefaultClusterID})
 			patch, err = MutateLabelFromCluster(mutate, awscluster.GetObjectMeta(), cluster, label.Release)

--- a/pkg/aws/g8scontrolplane/mutate_g8scontrolplane_AZ_test.go
+++ b/pkg/aws/g8scontrolplane/mutate_g8scontrolplane_AZ_test.go
@@ -21,6 +21,7 @@ import (
 
 var (
 	controlPlaneName      = "gmk24"
+	clusterName           = "gmk24"
 	controlPlaneNameSpace = "default"
 )
 
@@ -182,9 +183,10 @@ func getG8sControlPlaneRAWByte(replicaNum int, release string) ([]byte, error) {
 			Name:      controlPlaneName,
 			Namespace: controlPlaneNameSpace,
 			Labels: map[string]string{
-				"giantswarm.io/control-plane":   controlPlaneName,
-				"giantswarm.io/organization":    "giantswarm",
-				"release.giantswarm.io/version": release,
+				"giantswarm.io/control-plane":            controlPlaneName,
+				"cluster-operator.giantswarm.io/version": "1.2.3",
+				"giantswarm.io/organization":             "giantswarm",
+				"release.giantswarm.io/version":          release,
 			},
 		},
 		Spec: infrastructurev1alpha2.G8sControlPlaneSpec{

--- a/pkg/aws/g8scontrolplane/mutate_g8scontrolplane_AZ_test.go
+++ b/pkg/aws/g8scontrolplane/mutate_g8scontrolplane_AZ_test.go
@@ -21,7 +21,6 @@ import (
 
 var (
 	controlPlaneName      = "gmk24"
-	clusterName           = "gmk24"
 	controlPlaneNameSpace = "default"
 )
 

--- a/pkg/aws/g8scontrolplane/mutate_g8scontrolplane_infraref_test.go
+++ b/pkg/aws/g8scontrolplane/mutate_g8scontrolplane_infraref_test.go
@@ -128,9 +128,10 @@ func getG8sControlPlaneNoRefRAWByte() ([]byte, error) {
 			Name:      controlPlaneName,
 			Namespace: controlPlaneNameSpace,
 			Labels: map[string]string{
-				"giantswarm.io/control-plane":   controlPlaneName,
-				"giantswarm.io/organization":    "giantswarm",
-				"release.giantswarm.io/version": "11.5.0",
+				"giantswarm.io/control-plane":            controlPlaneName,
+				"cluster-operator.giantswarm.io/version": "1.2.3",
+				"giantswarm.io/organization":             "giantswarm",
+				"release.giantswarm.io/version":          "11.5.0",
 			},
 		},
 		Spec: infrastructurev1alpha2.G8sControlPlaneSpec{

--- a/pkg/key/common.go
+++ b/pkg/key/common.go
@@ -4,12 +4,23 @@ import (
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/label"
 )
 
+func AWSOperator(getter LabelsGetter) string {
+	return getter.GetLabels()[label.AWSOperatorVersion]
+}
+
 func Cluster(getter LabelsGetter) string {
 	return getter.GetLabels()[label.Cluster]
 }
 
+func ClusterOperator(getter LabelsGetter) string {
+	return getter.GetLabels()[label.ClusterOperatorVersion]
+}
+
 func ControlPlane(getter LabelsGetter) string {
 	return getter.GetLabels()[label.ControlPlane]
+}
+func Release(getter LabelsGetter) string {
+	return getter.GetLabels()[label.Release]
 }
 
 func MachineDeployment(getter LabelsGetter) string {
@@ -18,7 +29,4 @@ func MachineDeployment(getter LabelsGetter) string {
 
 func Organization(getter LabelsGetter) string {
 	return getter.GetLabels()[label.Organization]
-}
-func Release(getter LabelsGetter) string {
-	return getter.GetLabels()[label.Release]
 }

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -1,12 +1,13 @@
 package label
 
 const (
-	Certificate       = "giantswarm.io/certificate"
-	Cluster           = "giantswarm.io/cluster"
-	ControlPlane      = "giantswarm.io/control-plane"
-	MachineDeployment = "giantswarm.io/machine-deployment"
-	ManagedBy         = "giantswarm.io/managed-by"
-	OperatorVersion   = "cluster-operator.giantswarm.io/version"
-	Organization      = "giantswarm.io/organization"
-	Release           = "release.giantswarm.io/version"
+	Certificate            = "giantswarm.io/certificate"
+	Cluster                = "giantswarm.io/cluster"
+	ControlPlane           = "giantswarm.io/control-plane"
+	MachineDeployment      = "giantswarm.io/machine-deployment"
+	ManagedBy              = "giantswarm.io/managed-by"
+	ClusterOperatorVersion = "cluster-operator.giantswarm.io/version"
+	AWSOperatorVersion     = "aws-operator.giantswarm.io/version"
+	Organization           = "giantswarm.io/organization"
+	Release                = "release.giantswarm.io/version"
 )

--- a/pkg/unittest/default_cluster.go
+++ b/pkg/unittest/default_cluster.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	DefaultAWSOperatorVersion     = "7.3.0"
 	DefaultPodCIDR                = "10.2.0.0/16"
 	DefaultClusterDNSDomain       = "gauss.eu-west-1.aws.gigantic.io"
 	DefaultClusterRegion          = "eu-west-1"

--- a/pkg/unittest/default_cluster.go
+++ b/pkg/unittest/default_cluster.go
@@ -23,10 +23,10 @@ func DefaultAWSCluster() infrastructurev1alpha2.AWSCluster {
 	cr := infrastructurev1alpha2.AWSCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				label.Cluster:         DefaultClusterID,
-				label.OperatorVersion: "7.3.0",
-				label.Release:         "100.0.0",
-				label.Organization:    "example-organization",
+				label.Cluster:            DefaultClusterID,
+				label.AWSOperatorVersion: "7.3.0",
+				label.Release:            "100.0.0",
+				label.Organization:       "example-organization",
 			},
 			Name:      DefaultClusterID,
 			Namespace: metav1.NamespaceDefault,
@@ -102,10 +102,10 @@ func DefaultCluster() capiv1alpha2.Cluster {
 			Name:      DefaultClusterID,
 			Namespace: metav1.NamespaceDefault,
 			Labels: map[string]string{
-				label.Cluster:         DefaultClusterID,
-				label.OperatorVersion: "1.2.3",
-				label.Release:         "100.0.0",
-				label.Organization:    "example-organization",
+				label.Cluster:                DefaultClusterID,
+				label.ClusterOperatorVersion: "1.2.3",
+				label.Release:                "100.0.0",
+				label.Organization:           "example-organization",
 			},
 		},
 	}

--- a/pkg/unittest/default_control_plane.go
+++ b/pkg/unittest/default_control_plane.go
@@ -25,10 +25,10 @@ func DefaultAWSControlPlane() infrastructurev1alpha2.AWSControlPlane {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "a2wax",
 			Labels: map[string]string{
-				label.Cluster:         DefaultClusterID,
-				label.ControlPlane:    DefaultControlPlaneID,
-				label.OperatorVersion: "7.3.0",
-				label.Release:         "100.0.0",
+				label.Cluster:            DefaultClusterID,
+				label.ControlPlane:       DefaultControlPlaneID,
+				label.AWSOperatorVersion: "7.3.0",
+				label.Release:            "100.0.0",
 			},
 			Namespace: metav1.NamespaceDefault,
 		},
@@ -46,10 +46,10 @@ func DefaultG8sControlPlane() infrastructurev1alpha2.G8sControlPlane {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "a2wax",
 			Labels: map[string]string{
-				label.Cluster:         DefaultClusterID,
-				label.ControlPlane:    DefaultControlPlaneID,
-				label.OperatorVersion: "7.3.0",
-				label.Release:         "100.0.0",
+				label.Cluster:                DefaultClusterID,
+				label.ControlPlane:           DefaultControlPlaneID,
+				label.ClusterOperatorVersion: "7.3.0",
+				label.Release:                "100.0.0",
 			},
 			Namespace: metav1.NamespaceDefault,
 		},

--- a/pkg/unittest/default_machine_deployment.go
+++ b/pkg/unittest/default_machine_deployment.go
@@ -23,10 +23,10 @@ func DefaultMachineDeployment() apiv1alpha2.MachineDeployment {
 			Name:      DefaultMachineDeploymentID,
 			Namespace: metav1.NamespaceDefault,
 			Labels: map[string]string{
-				label.Cluster:           DefaultClusterID,
-				label.MachineDeployment: DefaultMachineDeploymentID,
-				label.OperatorVersion:   "7.3.0",
-				label.Release:           "100.0.0",
+				label.Cluster:                DefaultClusterID,
+				label.MachineDeployment:      DefaultMachineDeploymentID,
+				label.ClusterOperatorVersion: "7.3.0",
+				label.Release:                "100.0.0",
 			},
 		},
 		Status: apiv1alpha2.MachineDeploymentStatus{
@@ -46,10 +46,10 @@ func DefaultAWSMachineDeployment() infrastructurev1alpha2.AWSMachineDeployment {
 	cr := infrastructurev1alpha2.AWSMachineDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				label.Cluster:           DefaultClusterID,
-				label.MachineDeployment: DefaultMachineDeploymentID,
-				label.OperatorVersion:   "7.3.0",
-				label.Release:           "100.0.0",
+				label.Cluster:            DefaultClusterID,
+				label.MachineDeployment:  DefaultMachineDeploymentID,
+				label.AWSOperatorVersion: "7.3.0",
+				label.Release:            "100.0.0",
 			},
 			Name:      DefaultMachineDeploymentID,
 			Namespace: metav1.NamespaceDefault,


### PR DESCRIPTION
towards: https://github.com/giantswarm/giantswarm/issues/14025

This adds defaulting of the cluster-operator version label by making the label defaulting from the cluster CR generic.