### PR TITLE
default aws-operator version label from awscluster cr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Default the AWS Operator Version Label in `AWSControlplane`, `AWSMachinedeployment` Mutators and add generic label defaulting from AWSCluster CR.
 - Default the Cluster Operator Version Label in `G8sControlplane`, `Machinedeployment` Mutators and add generic label defaulting from cluster CR.
 - Default the Master attributes in the `AWSCluster` Mutator for pre-HA versions.
 - Default the Release Version Label and refactor the `G8sControlplane` and `AWSControlPlane` Mutators.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Mutating Webhook:
   - For pre-HA versions, replicas is always set to 1 for a single master cluster.
 - In a `G8sControlPlane` resource, the infrastructure reference will be set to point to the matching `AWSControlPlane` resource if it already exists.
 
+- In an `AWSControlplane` resource, the AWS Operator Version is defaulted based on the `AWSCluster` CR if it is not set. 
 - In an `AWSControlplane` resource, the Release Version is defaulted based on the `Cluster` CR if it is not set. 
 - In an `AWSControlPlane` resource, the Availability Zones will be defaulted if they are `nil`. 
   - For HA-Versions, in case the matching `G8sControlPlane` already exists, the number of AZs is determined by the number of `replicas` defined there. 
@@ -33,6 +34,7 @@ Mutating Webhook:
   - For Pre-HA-Versions, in case the matching `AWSCluster` already exists, the Instance Type is taken from there. 
 - On creation of an `AWSControlPlane` resource, the infrastructure reference of the according `G8sControlPlane` will be set if needed.
 
+- In an `AWSMachinedeployment` resource, the AWS Operator Version is defaulted based on the `AWSCluster` CR if it is not set. 
 - When a new `AWSMachineDeployment` is created, details are logged.
 - In an `AWSMachinedeployment` resource, the Release Version is defaulted based on the `Cluster` CR if it is not set. 
 

--- a/pkg/aws/awscontrolplane/mutate_awscontrolplane_AZ_test.go
+++ b/pkg/aws/awscontrolplane/mutate_awscontrolplane_AZ_test.go
@@ -227,9 +227,10 @@ func getAWSControlPlaneRAWByte(currentAvailabilityZone []string, currentInstance
 			Name:      controlPlaneName,
 			Namespace: controlPlaneNameSpace,
 			Labels: map[string]string{
-				"giantswarm.io/cluster":         clusterName,
-				"giantswarm.io/control-plane":   controlPlaneName,
-				"release.giantswarm.io/version": release,
+				"giantswarm.io/cluster":              clusterName,
+				"giantswarm.io/control-plane":        controlPlaneName,
+				"release.giantswarm.io/version":      release,
+				"aws-operator.giantswarm.io/version": unittest.DefaultAWSOperatorVersion,
 			},
 		},
 		Spec: infrastructurev1alpha2.AWSControlPlaneSpec{

--- a/pkg/unittest/default_cluster.go
+++ b/pkg/unittest/default_cluster.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	DefaultAWSOperatorVersion     = "7.3.0"
 	DefaultPodCIDR                = "10.2.0.0/16"
 	DefaultClusterDNSDomain       = "gauss.eu-west-1.aws.gigantic.io"
 	DefaultClusterRegion          = "eu-west-1"


### PR DESCRIPTION
Towards: giantswarm/giantswarm#14025
This adds defaulting of the aws-operator version label from the aws-cluster for awscontrolplane and awsmachinedeployment CRs.