### PR TITLE
defaulting aws-operator version based on release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Default the Cluster Operator Version Label in `Cluster` from `Release` CR.
 - Default the AWS Operator Version Label in `AWSCluster` from `Release` CR.
 - Default the AWS Operator Version Label in `AWSControlplane`, `AWSMachinedeployment` Mutators and add generic label defaulting from AWSCluster CR.
 - Default the Cluster Operator Version Label in `G8sControlplane`, `Machinedeployment` Mutators and add generic label defaulting from cluster CR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Default the AWS Operator Version Label in `AWSCluster` from `Release` CR.
 - Default the AWS Operator Version Label in `AWSControlplane`, `AWSMachinedeployment` Mutators and add generic label defaulting from AWSCluster CR.
 - Default the Cluster Operator Version Label in `G8sControlplane`, `Machinedeployment` Mutators and add generic label defaulting from cluster CR.
 - Default the Master attributes in the `AWSCluster` Mutator for pre-HA versions.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Mutating Webhook:
 - In an `AWSCluster` resource, the Pod CIDR is defaulted if it is not set. 
 - In an `AWSCluster` resource, in a pre-HA version, the Master attribute is defaulted if it is not set.
 
+- In a `Cluster` resource, the Cluster Operator Version is defaulted based on the `Release` CR if it is not set. 
+
 - In a `G8sControlplane` resource, the Cluster Operator Version is defaulted based on the `Cluster` CR if it is not set. 
 - In a `G8sControlplane` resource, the Release Version is defaulted based on the `Cluster` CR if it is not set. 
 - In a `G8sControlPlane` resource, when the `.spec.replicas` is changed from 1 to 3, the Availability Zones of the according `AWSControlPlane` will be defaulted if needed.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Giant Swarm Control Plane admission controller that implements the following rul
 
 Mutating Webhook:
 
+- In an `AWSCluster` resource, the AWS Operator Version is defaulted based on the `Release` CR if it is not set. 
 - In an `AWSCluster` resource, the Release Version is defaulted based on the `Cluster` CR if it is not set. 
 - In an `AWSCluster` resource, the Credential Secret is defaulted if it is not set. 
 - In an `AWSCluster` resource, the Region is defaulted if it is not set. 

--- a/helm/aws-admission-controller/templates/rbac.yaml
+++ b/helm/aws-admission-controller/templates/rbac.yaml
@@ -34,6 +34,7 @@ rules:
       - releases
     verbs:
       - "list"
+      - "get"
   - apiGroups:
       - ""
     resources:

--- a/helm/aws-admission-controller/templates/webhook.yaml
+++ b/helm/aws-admission-controller/templates/webhook.yaml
@@ -65,6 +65,25 @@ webhooks:
         operations:
           - CREATE
           - UPDATE
+  - name: clusters.{{ include "resource.default.name" . }}.giantswarm.io
+    admissionReviewVersions: [v1]
+    failurePolicy: Ignore
+    sideEffects: None
+    clientConfig:
+      service:
+        name: {{ include "resource.default.name" . }}
+        namespace: {{ include "resource.default.namespace" . }}
+        path: /mutate/cluster
+      caBundle: Cg==
+    rules:
+      - apiGroups: ["cluster.x-k8s.io"]
+        resources:
+          - clusters
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
   - name: g8scontrolplanes.{{ include "resource.default.name" . }}.giantswarm.io
     admissionReviewVersions: [v1]
     failurePolicy: Ignore

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/aws/awscluster"
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/aws/awscontrolplane"
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/aws/awsmachinedeployment"
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/aws/cluster"
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/aws/g8scontrolplane"
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/aws/machinedeployment"
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/aws/networkpool"
@@ -44,6 +45,11 @@ func main() {
 	awsmachinedeploymentMutator, err := awsmachinedeployment.NewMutator(config)
 	if err != nil {
 		log.Fatalf("Unable to create G8s Control Plane admitter: %v", err)
+	}
+
+	clusterMutator, err := cluster.NewMutator(config)
+	if err != nil {
+		panic(microerror.JSON(err))
 	}
 
 	g8scontrolplaneMutator, err := g8scontrolplane.NewMutator(config)
@@ -87,6 +93,7 @@ func main() {
 	handler.Handle("/mutate/awscluster", mutator.Handler(awsclusterMutator))
 	handler.Handle("/mutate/awsmachinedeployment", mutator.Handler(awsmachinedeploymentMutator))
 	handler.Handle("/mutate/awscontrolplane", mutator.Handler(awscontrolplaneMutator))
+	handler.Handle("/mutate/cluster", mutator.Handler(clusterMutator))
 	handler.Handle("/mutate/g8scontrolplane", mutator.Handler(g8scontrolplaneMutator))
 	handler.Handle("/mutate/machinedeployment", mutator.Handler(machinedeploymentMutator))
 	handler.Handle("/validate/awscluster", validator.Handler(awsclusterValidator))

--- a/pkg/aws/cluster/error.go
+++ b/pkg/aws/cluster/error.go
@@ -1,0 +1,41 @@
+package cluster
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var notAllowedError = &microerror.Error{
+	Kind: "notAllowedError",
+}
+
+// IsNotAllowed asserts notAllowedError.
+func IsNotAllowed(err error) bool {
+	return microerror.Cause(err) == notAllowedError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var parsingFailedError = &microerror.Error{
+	Kind: "parsingFailedError",
+}
+
+// IsParsingFailed asserts parsingFailedError.
+func IsParsingFailed(err error) bool {
+	return microerror.Cause(err) == parsingFailedError
+}

--- a/pkg/aws/cluster/mutate_cluster.go
+++ b/pkg/aws/cluster/mutate_cluster.go
@@ -1,0 +1,115 @@
+// Package cluster intercepts write activity to Cluster objects.
+package cluster
+
+import (
+	"github.com/blang/semver"
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	admissionv1 "k8s.io/api/admission/v1"
+	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+
+	"github.com/giantswarm/aws-admission-controller/v2/config"
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/aws"
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/key"
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/label"
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/mutator"
+)
+
+type Config struct {
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+}
+
+// Mutator for Cluster object.
+type Mutator struct {
+	k8sClient k8sclient.Interface
+	logger    micrologger.Logger
+}
+
+func NewMutator(config config.Config) (*Mutator, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	mutator := &Mutator{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return mutator, nil
+}
+
+// Mutate is the function executed for every matching webhook request.
+func (m *Mutator) Mutate(request *admissionv1.AdmissionRequest) ([]mutator.PatchOperation, error) {
+	var result []mutator.PatchOperation
+
+	if request.DryRun != nil && *request.DryRun {
+		return result, nil
+	}
+	if request.Operation == admissionv1.Create {
+		return m.MutateCreate(request)
+	}
+	return result, nil
+}
+
+// MutateCreate is the function executed for every create webhook request.
+func (m *Mutator) MutateCreate(request *admissionv1.AdmissionRequest) ([]mutator.PatchOperation, error) {
+	var result []mutator.PatchOperation
+	var patch []mutator.PatchOperation
+	var err error
+
+	// Parse incoming object
+	cluster := &capiv1alpha2.Cluster{}
+	if _, _, err := mutator.Deserializer.Decode(request.Object.Raw, nil, cluster); err != nil {
+		return nil, microerror.Maskf(parsingFailedError, "unable to parse Cluster: %v", err)
+	}
+
+	releaseVersion, err := aws.ReleaseVersion(cluster, patch)
+	if err != nil {
+		return nil, microerror.Maskf(parsingFailedError, "unable to parse release version from Cluster")
+	}
+
+	patch, err = m.MutateOperatorVersion(*cluster, releaseVersion)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	result = append(result, patch...)
+
+	return result, nil
+}
+
+func (m *Mutator) MutateOperatorVersion(cluster capiv1alpha2.Cluster, releaseVersion *semver.Version) ([]mutator.PatchOperation, error) {
+	var result []mutator.PatchOperation
+	var patch []mutator.PatchOperation
+	var err error
+
+	if key.ClusterOperator(&cluster) != "" {
+		return result, nil
+	}
+	// Retrieve the `Release` CR.
+	release, err := aws.FetchRelease(&aws.Mutator{K8sClient: m.k8sClient, Logger: m.logger}, releaseVersion)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// mutate the operator label
+	patch, err = aws.MutateLabelFromRelease(&aws.Mutator{K8sClient: m.k8sClient, Logger: m.logger}, &cluster, *release, label.ClusterOperatorVersion, "cluster-operator")
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	result = append(result, patch...)
+
+	return result, nil
+}
+
+func (m *Mutator) Log(keyVals ...interface{}) {
+	m.logger.Log(keyVals...)
+}
+
+func (m *Mutator) Resource() string {
+	return "cluster"
+}

--- a/pkg/aws/cluster/mutate_test.go
+++ b/pkg/aws/cluster/mutate_test.go
@@ -1,0 +1,83 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/aws"
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/label"
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/mutator"
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/unittest"
+)
+
+func TestMutateOperatorVersion(t *testing.T) {
+	testCases := []struct {
+		ctx  context.Context
+		name string
+
+		currentOperator string
+		expectedPatch   string
+	}{
+		{
+			// Don't default the Operator Label if it is set
+			name: "case 0",
+			ctx:  context.Background(),
+
+			currentOperator: unittest.DefaultClusterOperatorVersion,
+			expectedPatch:   "",
+		},
+		{
+			// Default the Operator Label if it is not set
+			name: "case 1",
+			ctx:  context.Background(),
+
+			currentOperator: "",
+			expectedPatch:   unittest.DefaultClusterOperatorVersion,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+			var updatedOperator string
+
+			fakeK8sClient := unittest.FakeK8sClient()
+			mutate := &Mutator{
+				k8sClient: fakeK8sClient,
+				logger:    microloggertest.New(),
+			}
+			// create release
+			release := unittest.DefaultRelease()
+			err = fakeK8sClient.CtrlClient().Create(tc.ctx, &release)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// run mutate function to default cluster operator label
+			var patch []mutator.PatchOperation
+			cluster := unittest.DefaultCluster()
+			cluster.SetLabels(map[string]string{label.ClusterOperatorVersion: tc.currentOperator, label.Release: unittest.DefaultReleaseVersion})
+			releaseVersion, err := aws.ReleaseVersion(cluster.GetObjectMeta(), patch)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			patch, err = mutate.MutateOperatorVersion(cluster, releaseVersion)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// parse patches
+			for _, p := range patch {
+				if p.Path == fmt.Sprintf("/metadata/labels/%s", aws.EscapeJSONPatchString(label.ClusterOperatorVersion)) {
+					updatedOperator = p.Value.(string)
+				}
+			}
+			// check if the release label is as expected
+			if tc.expectedPatch != updatedOperator {
+				t.Fatalf("expected %#q to be equal to %#q", tc.expectedPatch, updatedOperator)
+			}
+		})
+	}
+}

--- a/pkg/aws/common_test.go
+++ b/pkg/aws/common_test.go
@@ -171,7 +171,7 @@ func Test_PauseTimeIsValid(t *testing.T) {
 	}
 }
 
-func TestReleaseVersion(t *testing.T) {
+func TestLabelFromCluster(t *testing.T) {
 	testCases := []struct {
 		ctx  context.Context
 		name string
@@ -229,7 +229,7 @@ func TestReleaseVersion(t *testing.T) {
 	}
 }
 
-func TestAWSOperatorVersion(t *testing.T) {
+func TestLabelFromAWSCluster(t *testing.T) {
 	testCases := []struct {
 		ctx  context.Context
 		name string
@@ -270,6 +270,64 @@ func TestAWSOperatorVersion(t *testing.T) {
 			awscontrolplane := unittest.DefaultAWSControlPlane()
 			awscontrolplane.SetLabels(map[string]string{label.AWSOperatorVersion: tc.currentOperator, label.Cluster: unittest.DefaultClusterID})
 			patch, err = MutateLabelFromAWSCluster(mutate, awscontrolplane.GetObjectMeta(), awscluster, label.AWSOperatorVersion)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// parse patches
+			for _, p := range patch {
+				if p.Path == fmt.Sprintf("/metadata/labels/%s", EscapeJSONPatchString(label.AWSOperatorVersion)) {
+					updatedOperator = p.Value.(string)
+				}
+			}
+			// check if the release label is as expected
+			if tc.expectedPatch != updatedOperator {
+				t.Fatalf("expected %#q to be equal to %#q", tc.expectedPatch, updatedOperator)
+			}
+		})
+	}
+}
+
+func TestLabelFromRelease(t *testing.T) {
+	testCases := []struct {
+		ctx  context.Context
+		name string
+
+		currentOperator string
+		expectedPatch   string
+	}{
+		{
+			// Don't default the Operator Label if it is set
+			name: "case 0",
+			ctx:  context.Background(),
+
+			currentOperator: unittest.DefaultAWSOperatorVersion,
+			expectedPatch:   "",
+		},
+		{
+			// Default the Operator Label if it is not set
+			name: "case 1",
+			ctx:  context.Background(),
+
+			currentOperator: "",
+			expectedPatch:   unittest.DefaultAWSOperatorVersion,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+			var updatedOperator string
+
+			fakeK8sClient := unittest.FakeK8sClient()
+			mutate := &Mutator{
+				K8sClient: fakeK8sClient,
+				Logger:    microloggertest.New(),
+			}
+			// run mutate function to default AWSControlplane operator label
+			var patch []mutator.PatchOperation
+			awscluster := unittest.DefaultAWSCluster()
+			release := unittest.DefaultRelease()
+			awscluster.SetLabels(map[string]string{label.AWSOperatorVersion: tc.currentOperator, label.Release: unittest.DefaultReleaseVersion})
+			patch, err = MutateLabelFromRelease(mutate, awscluster.GetObjectMeta(), release, label.AWSOperatorVersion, "aws-operator")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/unittest/default_cluster.go
+++ b/pkg/unittest/default_cluster.go
@@ -14,6 +14,7 @@ const (
 	DefaultAWSOperatorVersion     = "7.3.0"
 	DefaultPodCIDR                = "10.2.0.0/16"
 	DefaultClusterDNSDomain       = "gauss.eu-west-1.aws.gigantic.io"
+	DefaultClusterOperatorVersion = "1.1.1"
 	DefaultClusterRegion          = "eu-west-1"
 	DefaultReleaseVersion         = "100.0.0"
 	DefaultMasterInstanceType     = "m4.xlarge"

--- a/pkg/unittest/default_release.go
+++ b/pkg/unittest/default_release.go
@@ -1,0 +1,33 @@
+package unittest
+
+import (
+	releasev1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	DefaultReleaseName = "v100.0.0"
+)
+
+func DefaultRelease() releasev1alpha1.Release {
+	cr := releasev1alpha1.Release{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DefaultReleaseName,
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: releasev1alpha1.ReleaseSpec{
+			Components: []releasev1alpha1.ReleaseSpecComponent{
+				{
+					Name:    "aws-operator",
+					Version: DefaultAWSOperatorVersion,
+				},
+				{
+					Name:    "cluster-operator",
+					Version: DefaultClusterOperatorVersion,
+				},
+			},
+		},
+	}
+
+	return cr
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14025
We want to set the aws-operator version based on the release-version of the `awscluster`.