### PR TITLE
Return 400 status code in the validator response if a request is found invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Set `400` status code in the validator response if a request is invalid.
+
 ## [2.2.2] - 2020-11-10
 
 ### Added

--- a/pkg/validator/handler.go
+++ b/pkg/validator/handler.go
@@ -97,6 +97,8 @@ func errorResponse(uid types.UID, err error) *admissionv1.AdmissionResponse {
 		Allowed: false,
 		UID:     uid,
 		Result: &metav1.Status{
+			Reason:  metav1.StatusReasonBadRequest,
+			Code:    http.StatusBadRequest,
 			Message: err.Error(),
 		},
 	}


### PR DESCRIPTION
This will return a `400` status code in the validator response if an error was thrown in the validator.

For 2 reasons:
* With this, it is really easy to determine from other services (e.g. GS API) if the resource creation/update/etc. failed because something was wrong in the payload, rather than considering it was an internal error in the K8s API/admission controllers
* We also do this in `azure-admission-controller` 😬 Consistency!