### PR TITLE
default to the newest release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Default the Release Version Label in `Cluster` to the newest active production release.
+
 ## [2.5.0] - 2020-12-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Mutating Webhook:
 - In an `AWSCluster` resource, the Pod CIDR is defaulted if it is not set. 
 - In an `AWSCluster` resource, in a pre-HA version, the Master attribute is defaulted if it is not set.
 
+- In a `Cluster` resource, the Release Version is defaulted to the newest active production version if it is not set. 
 - In a `Cluster` resource, the Cluster Operator Version is defaulted based on the `Release` CR if it is not set. 
 
 - In a `G8sControlplane` resource, the Cluster Operator Version is defaulted based on the `Cluster` CR if it is not set. 

--- a/pkg/aws/common.go
+++ b/pkg/aws/common.go
@@ -51,6 +51,11 @@ func IsHAVersion(releaseVersion *semver.Version) bool {
 	return releaseVersion.GE(*HAVersion)
 }
 
+// IsVersionProductionReady returns whether a given releaseVersion is not a prerelease or test version
+func IsVersionProductionReady(version *semver.Version) bool {
+	return len(version.Pre) == 0 && len(version.Build) == 0
+}
+
 // IsValidMasterReplicas returns whether a given number is a valid number of Master node replicas
 func IsValidMasterReplicas(replicas int) bool {
 	for _, r := range ValidMasterReplicas() {

--- a/pkg/aws/common_fetcher.go
+++ b/pkg/aws/common_fetcher.go
@@ -228,7 +228,7 @@ func FetchNewestReleaseVersion(m *Handler) (*semver.Version, error) {
 			activeReleases = append(activeReleases, *version)
 		}
 	}
-	if len(infrastructurev1alpha2.NewAWSClusterTypeMeta().APIVersion) == 0 {
+	if len(activeReleases) == 0 {
 		return nil, microerror.Maskf(notFoundError, "Could not find any active releases.")
 	}
 	// Sort releases by version (descending).

--- a/pkg/aws/common_test.go
+++ b/pkg/aws/common_test.go
@@ -428,7 +428,10 @@ func TestNewestReleaseVersion(t *testing.T) {
 				release := unittest.DefaultRelease()
 				release.SetName(r.Name)
 				release.Spec.State = r.State
-				fakeK8sClient.CtrlClient().Create(tc.ctx, &release)
+				err = fakeK8sClient.CtrlClient().Create(tc.ctx, &release)
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 			// run fetcher to get newest active release version
 			version, err := FetchNewestReleaseVersion(handle)

--- a/pkg/aws/common_test.go
+++ b/pkg/aws/common_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 
+	releasev1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/release/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/label"
@@ -340,6 +341,103 @@ func TestLabelFromRelease(t *testing.T) {
 			// check if the release label is as expected
 			if tc.expectedPatch != updatedOperator {
 				t.Fatalf("expected %#q to be equal to %#q", tc.expectedPatch, updatedOperator)
+			}
+		})
+	}
+}
+
+func TestNewestReleaseVersion(t *testing.T) {
+	testCases := []struct {
+		ctx  context.Context
+		name string
+
+		releases        []unittest.ReleaseData
+		expectedVersion string
+	}{
+		{
+			// take only active releases
+			name: "case 0",
+			ctx:  context.Background(),
+
+			releases: []unittest.ReleaseData{
+				{
+					Name:  "v1.2.3",
+					State: releasev1alpha1.StateActive,
+				},
+				{
+					Name:  "v2.1.0",
+					State: releasev1alpha1.StateDeprecated,
+				},
+			},
+			expectedVersion: "1.2.3",
+		},
+		{
+			// don't take dev versions
+			name: "case 1",
+			ctx:  context.Background(),
+
+			releases: []unittest.ReleaseData{
+				{
+					Name:  "v1.2.3",
+					State: releasev1alpha1.StateActive,
+				},
+				{
+					Name:  "v3.2.3-dev",
+					State: releasev1alpha1.StateActive,
+				},
+			},
+			expectedVersion: "1.2.3",
+		},
+		{
+			// sort releases correctly
+			name: "case 1",
+			ctx:  context.Background(),
+
+			releases: []unittest.ReleaseData{
+				{
+					Name:  "v1.1.1",
+					State: releasev1alpha1.StateActive,
+				},
+				{
+					Name:  "v0.2.3",
+					State: releasev1alpha1.StateActive,
+				},
+				{
+					Name:  "v1.2.3",
+					State: releasev1alpha1.StateActive,
+				},
+				{
+					Name:  "v1.2.1",
+					State: releasev1alpha1.StateActive,
+				},
+			},
+			expectedVersion: "1.2.3",
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+
+			fakeK8sClient := unittest.FakeK8sClient()
+			handle := &Handler{
+				K8sClient: fakeK8sClient,
+				Logger:    microloggertest.New(),
+			}
+			// create releases for testing
+			for _, r := range tc.releases {
+				release := unittest.DefaultRelease()
+				release.SetName(r.Name)
+				release.Spec.State = r.State
+				fakeK8sClient.CtrlClient().Create(tc.ctx, &release)
+			}
+			// run fetcher to get newest active release version
+			version, err := FetchNewestReleaseVersion(handle)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// check if the release version is as expected
+			if tc.expectedVersion != version.String() {
+				t.Fatalf("expected %#q to be equal to %#q", tc.expectedVersion, version.String())
 			}
 		})
 	}

--- a/pkg/unittest/default_release.go
+++ b/pkg/unittest/default_release.go
@@ -9,6 +9,11 @@ const (
 	DefaultReleaseName = "v100.0.0"
 )
 
+type ReleaseData struct {
+	Name  string
+	State releasev1alpha1.ReleaseState
+}
+
 func DefaultRelease() releasev1alpha1.Release {
 	cr := releasev1alpha1.Release{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/198
This introduces a fetching function that lists all available releases on the installation and picks the latest production ready release to default the release version label of a `cluster` CR.