### PR TITLE
adding defaulting of the operator version for upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Default the Operator Version Label in `Cluster` to match the new release during upgrade.
 - Default the Release Version Label in `Cluster` to the newest active production release.
 
 ## [2.5.0] - 2020-12-01

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Mutating Webhook:
 
 - In a `Cluster` resource, the Release Version is defaulted to the newest active production version if it is not set. 
 - In a `Cluster` resource, the Cluster Operator Version is defaulted based on the `Release` CR if it is not set. 
+- In a `Cluster` resource, the Cluster Operator Version is defaulted based on the new release version during an upgrade. 
 
 - In a `G8sControlplane` resource, the Cluster Operator Version is defaulted based on the `Cluster` CR if it is not set. 
 - In a `G8sControlplane` resource, the Release Version is defaulted based on the `Cluster` CR if it is not set. 

--- a/pkg/aws/cluster/mutate_cluster.go
+++ b/pkg/aws/cluster/mutate_cluster.go
@@ -56,7 +56,7 @@ func (m *Mutator) Mutate(request *admissionv1.AdmissionRequest) ([]mutator.Patch
 		return m.MutateCreate(request)
 	}
 	if request.Operation == admissionv1.Update {
-		return m.MutateCreate(request)
+		return m.MutateUpdate(request)
 	}
 	return result, nil
 }

--- a/pkg/aws/cluster/mutate_test.go
+++ b/pkg/aws/cluster/mutate_test.go
@@ -81,3 +81,74 @@ func TestMutateOperatorVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestMutateReleaseUpdate(t *testing.T) {
+	testCases := []struct {
+		ctx  context.Context
+		name string
+
+		newVersion    string
+		oldVersion    string
+		expectedPatch string
+	}{
+		{
+			// Don't default the Operator Label if there is no upgrade
+			name: "case 0",
+			ctx:  context.Background(),
+
+			newVersion:    unittest.DefaultReleaseVersion,
+			oldVersion:    unittest.DefaultReleaseVersion,
+			expectedPatch: "",
+		},
+		{
+			// Default the Operator Label if there is an upgrade
+			name: "case 1",
+			ctx:  context.Background(),
+
+			newVersion:    unittest.DefaultReleaseVersion,
+			oldVersion:    "99.9.9",
+			expectedPatch: unittest.DefaultClusterOperatorVersion,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+			var updatedOperator string
+
+			fakeK8sClient := unittest.FakeK8sClient()
+			mutate := &Mutator{
+				k8sClient: fakeK8sClient,
+				logger:    microloggertest.New(),
+			}
+			// create release
+			release := unittest.DefaultRelease()
+			err = fakeK8sClient.CtrlClient().Create(tc.ctx, &release)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// create old and new objects
+			cluster := unittest.DefaultCluster()
+			oldCluster := unittest.DefaultCluster()
+			cluster.SetLabels(map[string]string{label.Release: tc.newVersion})
+			oldCluster.SetLabels(map[string]string{label.Release: tc.oldVersion})
+
+			// run mutate function to default cluster operator label
+			var patch []mutator.PatchOperation
+			patch, err = mutate.MutateReleaseUpdate(cluster, oldCluster)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// parse patches
+			for _, p := range patch {
+				if p.Path == fmt.Sprintf("/metadata/labels/%s", aws.EscapeJSONPatchString(label.ClusterOperatorVersion)) {
+					updatedOperator = p.Value.(string)
+				}
+			}
+			// check if the release label is as expected
+			if tc.expectedPatch != updatedOperator {
+				t.Fatalf("expected %#q to be equal to %#q", tc.expectedPatch, updatedOperator)
+			}
+		})
+	}
+}

--- a/pkg/aws/common_mutator.go
+++ b/pkg/aws/common_mutator.go
@@ -72,13 +72,13 @@ func MutateLabelFromCluster(m *Handler, meta metav1.Object, cluster capiv1alpha2
 func MutateLabelFromRelease(m *Handler, meta metav1.Object, release releasev1alpha1.Release, label string, component string) ([]mutator.PatchOperation, error) {
 	var result []mutator.PatchOperation
 
-	if meta.GetLabels()[label] != "" {
-		return result, nil
-	}
 	// Extract version from release
 	value := GetReleaseComponentLabels(release)[component]
 	if value == "" {
 		return nil, microerror.Maskf(notFoundError, "Release %s did not specify version of %s.", release.GetName(), component)
+	}
+	if meta.GetLabels()[label] == value {
+		return result, nil
 	}
 	m.Logger.Log("level", "debug", "message", fmt.Sprintf("Label %s will be defaulted to %s from Release %s.",
 		label,

--- a/pkg/aws/common_mutator.go
+++ b/pkg/aws/common_mutator.go
@@ -80,7 +80,7 @@ func MutateLabelFromRelease(m *Handler, meta metav1.Object, release releasev1alp
 	if value == "" {
 		return nil, microerror.Maskf(notFoundError, "Release %s did not specify version of %s.", release.GetName(), component)
 	}
-	m.Logger.Log("level", "debug", "message", fmt.Sprintf("Label %s is not set and will be defaulted to %s from Release %s.",
+	m.Logger.Log("level", "debug", "message", fmt.Sprintf("Label %s will be defaulted to %s from Release %s.",
 		label,
 		value,
 		release.GetName()))


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/13477
We want to make sure that on update the operator label is set correctly.