### PR TITLE
Adding label key validation for  CR for giantswarm.io labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Adding label value validation for `Cluster` CR for non-version labels.
+- Adding label key validation for `Cluster` CR for `giantswarm.io` labels.
 
 ## [2.6.0] - 2020-12-07
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Validating Webhook:
 
 - In a `AWSMachineDeployment` resource, it validates the Machine Deployment ID is matching against `MachineDeployment` resource.
 
-- In a `Cluster` resource, the non-version label values are not allowed to be deleted or renamed by whitelisted users and users in restricted groups. 
+- In a `Cluster` resource, the non-version label values are not allowed to be deleted or renamed by admin users and users in restricted groups. 
+- In a `Cluster` resource, the `giantswarm.io` label keys are not allowed to be deleted or renamed by admin users and users in restricted groups. 
 
 - In a `NetworkPool` resource, it validates the .Spec.CIDRBlock from other NetworkPools and also checks if there's overlapping from Docker CIDR, Kubernetes cluster IP range or tenant cluster CIDR.
 

--- a/pkg/aws/cluster/validate_cluster.go
+++ b/pkg/aws/cluster/validate_cluster.go
@@ -62,6 +62,10 @@ func (v *Validator) ValidateUpdate(request *admissionv1.AdmissionRequest) (bool,
 	}
 
 	if v.isAdmin(request.UserInfo) || v.isInRestrictedGroup(request.UserInfo) {
+		err = v.ClusterLabelKeysValid(oldCluster, cluster)
+		if err != nil {
+			return false, microerror.Mask(err)
+		}
 		err = v.ClusterLabelValuesValid(oldCluster, cluster)
 		if err != nil {
 			return false, microerror.Mask(err)
@@ -69,6 +73,10 @@ func (v *Validator) ValidateUpdate(request *admissionv1.AdmissionRequest) (bool,
 	}
 
 	return true, nil
+}
+
+func (v *Validator) ClusterLabelKeysValid(oldCluster *capiv1alpha2.Cluster, newCluster *capiv1alpha2.Cluster) error {
+	return aws.ValidateLabelKeys(&aws.Handler{K8sClient: v.k8sClient, Logger: v.logger}, oldCluster, newCluster)
 }
 
 func (v *Validator) ClusterLabelValuesValid(oldCluster *capiv1alpha2.Cluster, newCluster *capiv1alpha2.Cluster) error {

--- a/pkg/aws/common.go
+++ b/pkg/aws/common.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"strings"
+
 	"github.com/blang/semver"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -22,6 +24,9 @@ const (
 
 	// FirstHARelease is the first GS release for AWS that supports HA Masters
 	FirstHARelease = "11.4.0"
+
+	// GiantSwarmLabelPart is the part of label keys that shows that they are protected giantswarm labels
+	GiantSwarmLabelPart = "giantswarm.io"
 )
 
 const (
@@ -54,6 +59,14 @@ func ValidLabelAdmins() []string {
 // VersionLabels are the labels which are considered version labels
 func VersionLabels() []string {
 	return []string{label.AWSOperatorVersion, label.ClusterOperatorVersion, label.Release}
+}
+
+// IsGiantSwarmLabel returns whether a label is considered a giantswarm label
+func IsGiantSwarmLabel(label string) bool {
+	if strings.Contains(label, GiantSwarmLabelPart) {
+		return true
+	}
+	return false
 }
 
 // IsHAVersion returns whether a given releaseVersion supports HA Masters

--- a/pkg/aws/common.go
+++ b/pkg/aws/common.go
@@ -63,10 +63,7 @@ func VersionLabels() []string {
 
 // IsGiantSwarmLabel returns whether a label is considered a giantswarm label
 func IsGiantSwarmLabel(label string) bool {
-	if strings.Contains(label, GiantSwarmLabelPart) {
-		return true
-	}
-	return false
+	return strings.Contains(label, GiantSwarmLabelPart)
 }
 
 // IsHAVersion returns whether a given releaseVersion supports HA Masters

--- a/pkg/aws/common_validator.go
+++ b/pkg/aws/common_validator.go
@@ -9,6 +9,24 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func ValidateLabelKeys(m *Handler, old metav1.Object, new metav1.Object) error {
+	// validate for each giantswarm.io label that its value has not been modified
+	oldLabels := old.GetLabels()
+	newLabels := new.GetLabels()
+	for key := range oldLabels {
+		if !IsGiantSwarmLabel(key) {
+			continue
+		}
+		if _, ok := newLabels[key]; !ok {
+			return microerror.Maskf(notAllowedError, fmt.Sprintf("User is not allowed to rename or delete label key %s.",
+				key),
+			)
+		}
+	}
+
+	return nil
+}
+
 func ValidateLabelValues(m *Handler, old metav1.Object, new metav1.Object) error {
 	// validate for each non-version label that its value has not been modified
 	oldLabels := old.GetLabels()

--- a/pkg/unittest/default_labels.go
+++ b/pkg/unittest/default_labels.go
@@ -10,5 +10,6 @@ func DefaultLabels() map[string]string {
 		label.ClusterOperatorVersion: "1.2.3",
 		label.Release:                "100.0.0",
 		label.Organization:           "example-organization",
+		"example-key":                "example-value",
 	}
 }


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/15124

This is a copy of the rule c) from gatekeeper. If a user in a restricted group or with an admin username tries to delete or rename `giantswarm.io` label keys on the cluster resource, it will be rejected.