### PR TITLE
allow users to change release version label to valid values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adding label value validation for `Cluster` CR for non-version labels.
 - Adding label key validation for `Cluster` CR for `giantswarm.io` labels.
+- Adding label value validation for `Cluster` CR for version labels.
 
 ## [2.6.0] - 2020-12-07
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Validating Webhook:
 
 - In a `AWSMachineDeployment` resource, it validates the Machine Deployment ID is matching against `MachineDeployment` resource.
 
+- In a `Cluster` resource, the  release version label can only be changed to an existing and non-deprecated release by admin users and users in restricted groups. 
 - In a `Cluster` resource, the non-version label values are not allowed to be deleted or renamed by admin users and users in restricted groups. 
 - In a `Cluster` resource, the `giantswarm.io` label keys are not allowed to be deleted or renamed by admin users and users in restricted groups. 
 

--- a/pkg/aws/cluster/validate_cluster_test.go
+++ b/pkg/aws/cluster/validate_cluster_test.go
@@ -1,0 +1,104 @@
+package cluster
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	releasev1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/unittest"
+)
+
+func TestValidateReleaseVersion(t *testing.T) {
+	testCases := []struct {
+		ctx  context.Context
+		name string
+
+		newReleaseVersion string
+		valid             bool
+	}{
+		{
+			// Version unchanged
+			name: "case 0",
+			ctx:  context.Background(),
+
+			newReleaseVersion: unittest.DefaultReleaseVersion,
+			valid:             true,
+		},
+		{
+			// version changed to valid release
+			name: "case 1",
+			ctx:  context.Background(),
+
+			newReleaseVersion: "1.0.0",
+			valid:             true,
+		},
+		{
+			// version changed to deprecated release
+			name: "case 2",
+			ctx:  context.Background(),
+
+			newReleaseVersion: "2.0.0",
+			valid:             false,
+		},
+		{
+			// version changed to invalid release
+			name: "case 3",
+			ctx:  context.Background(),
+
+			newReleaseVersion: "3.0.0",
+			valid:             false,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+
+			fakeK8sClient := unittest.FakeK8sClient()
+			handle := &Validator{
+				k8sClient: fakeK8sClient,
+				logger:    microloggertest.New(),
+			}
+
+			// create releases for testing
+			releases := []unittest.ReleaseData{
+				{
+					Name:  "v1.0.0",
+					State: releasev1alpha1.StateActive,
+				},
+				{
+					Name:  "v2.0.0",
+					State: releasev1alpha1.StateDeprecated,
+				},
+			}
+			for _, r := range releases {
+				release := unittest.DefaultRelease()
+				release.SetName(r.Name)
+				release.Spec.State = r.State
+				err = fakeK8sClient.CtrlClient().Create(tc.ctx, &release)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// create old and new object with release version labels
+			oldObject := unittest.DefaultCluster()
+			newObject := unittest.DefaultCluster()
+			newLabels := unittest.DefaultLabels()
+			newLabels[label.ReleaseVersion] = tc.newReleaseVersion
+			newObject.SetLabels(newLabels)
+
+			// check if the result is as expected
+			err = handle.ReleaseVersionValid(&oldObject, &newObject)
+			if tc.valid && err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+			if !tc.valid && err == nil {
+				t.Fatalf("expected error but returned %v", err)
+			}
+		})
+	}
+}

--- a/pkg/aws/common.go
+++ b/pkg/aws/common.go
@@ -58,7 +58,7 @@ func ValidLabelAdmins() []string {
 
 // VersionLabels are the labels which are considered version labels
 func VersionLabels() []string {
-	return []string{label.AWSOperatorVersion, label.ClusterOperatorVersion, label.Release}
+	return []string{label.Release}
 }
 
 // IsGiantSwarmLabel returns whether a label is considered a giantswarm label

--- a/pkg/aws/common.go
+++ b/pkg/aws/common.go
@@ -58,7 +58,7 @@ func ValidLabelAdmins() []string {
 
 // VersionLabels are the labels which are considered version labels
 func VersionLabels() []string {
-	return []string{label.Release}
+	return []string{label.Release, label.ClusterOperatorVersion}
 }
 
 // IsGiantSwarmLabel returns whether a label is considered a giantswarm label

--- a/pkg/aws/common_validator.go
+++ b/pkg/aws/common_validator.go
@@ -32,7 +32,7 @@ func ValidateLabelValues(m *Handler, old metav1.Object, new metav1.Object) error
 	oldLabels := old.GetLabels()
 	newLabels := new.GetLabels()
 	for key, value := range oldLabels {
-		if IsVersionLabel(key) {
+		if IsVersionLabel(key) || !IsGiantSwarmLabel(key) {
 			continue
 		}
 		if value != newLabels[key] {

--- a/pkg/aws/common_validator_test.go
+++ b/pkg/aws/common_validator_test.go
@@ -260,7 +260,7 @@ func TestValidateLabelValues(t *testing.T) {
 
 			newLabels: map[string]string{
 				label.Cluster:                unittest.DefaultClusterID,
-				label.ClusterOperatorVersion: unittest.DefaultClusterOperatorVersion,
+				label.ClusterOperatorVersion: "1.2.3",
 				label.Release:                "0.0.0",
 				label.Organization:           "example-organization",
 			},


### PR DESCRIPTION
Towards: 
https://github.com/giantswarm/giantswarm/issues/15124
https://github.com/giantswarm/giantswarm/issues/13477

This adds label protection and validation for version labels from gatekeeper (rule b) and extends it to allow users to upgrade clusters. Changes to the release version label on the 'cluster' CR by users will be rejected if the release does not exist or is deprecated. All other `giantswarm.io` version labels can not be changed by users.