### PR TITLE
skip validation and defaulting for CAPI release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Do not validate and mutate for CAPI controller release versions
 - Adding validation for worker instance types in `AWSMachinedeployment` CR.
 - Prevent max number of nodes in `AWSMachinedeployment` CR to be 0 or smaller than min number of nodes.
 - Prevent upgrades (changing release version label on `Cluster` CR) if the Cluster has not transitioned yet.

--- a/pkg/aws/cluster/mutate_cluster.go
+++ b/pkg/aws/cluster/mutate_cluster.go
@@ -73,6 +73,14 @@ func (m *Mutator) MutateCreate(request *admissionv1.AdmissionRequest) ([]mutator
 		return nil, microerror.Maskf(parsingFailedError, "unable to parse Cluster: %v", err)
 	}
 
+	capi, err := aws.IsCAPIRelease(cluster)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	if capi {
+		return result, nil
+	}
+
 	patch, err = m.MutateReleaseVersion(*cluster)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -106,6 +114,14 @@ func (m *Mutator) MutateUpdate(request *admissionv1.AdmissionRequest) ([]mutator
 	}
 	if _, _, err := mutator.Deserializer.Decode(request.OldObject.Raw, nil, oldCluster); err != nil {
 		return nil, microerror.Maskf(parsingFailedError, "unable to parse old Cluster: %v", err)
+	}
+
+	capi, err := aws.IsCAPIRelease(cluster)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	if capi {
+		return result, nil
 	}
 
 	patch, err = m.MutateReleaseUpdate(*cluster, *oldCluster)

--- a/pkg/aws/cluster/mutate_cluster.go
+++ b/pkg/aws/cluster/mutate_cluster.go
@@ -73,10 +73,7 @@ func (m *Mutator) MutateCreate(request *admissionv1.AdmissionRequest) ([]mutator
 		return nil, microerror.Maskf(parsingFailedError, "unable to parse Cluster: %v", err)
 	}
 
-	capi, err := aws.IsCAPIRelease(cluster)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
+	capi, _ := aws.IsCAPIRelease(cluster)
 	if capi {
 		return result, nil
 	}
@@ -116,10 +113,7 @@ func (m *Mutator) MutateUpdate(request *admissionv1.AdmissionRequest) ([]mutator
 		return nil, microerror.Maskf(parsingFailedError, "unable to parse old Cluster: %v", err)
 	}
 
-	capi, err := aws.IsCAPIRelease(cluster)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
+	capi, _ := aws.IsCAPIRelease(cluster)
 	if capi {
 		return result, nil
 	}

--- a/pkg/aws/cluster/mutate_cluster.go
+++ b/pkg/aws/cluster/mutate_cluster.go
@@ -73,7 +73,10 @@ func (m *Mutator) MutateCreate(request *admissionv1.AdmissionRequest) ([]mutator
 		return nil, microerror.Maskf(parsingFailedError, "unable to parse Cluster: %v", err)
 	}
 
-	capi, _ := aws.IsCAPIRelease(cluster)
+	capi, err := aws.IsCAPIRelease(cluster)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
 	if capi {
 		return result, nil
 	}
@@ -113,7 +116,10 @@ func (m *Mutator) MutateUpdate(request *admissionv1.AdmissionRequest) ([]mutator
 		return nil, microerror.Maskf(parsingFailedError, "unable to parse old Cluster: %v", err)
 	}
 
-	capi, _ := aws.IsCAPIRelease(cluster)
+	capi, err := aws.IsCAPIRelease(cluster)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
 	if capi {
 		return result, nil
 	}

--- a/pkg/aws/cluster/validate_cluster.go
+++ b/pkg/aws/cluster/validate_cluster.go
@@ -63,6 +63,14 @@ func (v *Validator) ValidateUpdate(request *admissionv1.AdmissionRequest) (bool,
 		return false, microerror.Maskf(parsingFailedError, "unable to parse old Cluster: %v", err)
 	}
 
+	capi, err := aws.IsCAPIRelease(cluster)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+	if capi {
+		return true, nil
+	}
+
 	if v.isAdmin(request.UserInfo) || v.isInRestrictedGroup(request.UserInfo) {
 		err = v.ClusterStatusValid(oldCluster, cluster)
 		if err != nil {

--- a/pkg/aws/cluster/validate_cluster.go
+++ b/pkg/aws/cluster/validate_cluster.go
@@ -63,7 +63,10 @@ func (v *Validator) ValidateUpdate(request *admissionv1.AdmissionRequest) (bool,
 		return false, microerror.Maskf(parsingFailedError, "unable to parse old Cluster: %v", err)
 	}
 
-	capi, _ := aws.IsCAPIRelease(cluster)
+	capi, err := aws.IsCAPIRelease(cluster)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
 	if capi {
 		return true, nil
 	}

--- a/pkg/aws/cluster/validate_cluster.go
+++ b/pkg/aws/cluster/validate_cluster.go
@@ -63,10 +63,7 @@ func (v *Validator) ValidateUpdate(request *admissionv1.AdmissionRequest) (bool,
 		return false, microerror.Maskf(parsingFailedError, "unable to parse old Cluster: %v", err)
 	}
 
-	capi, err := aws.IsCAPIRelease(cluster)
-	if err != nil {
-		return false, microerror.Mask(err)
-	}
+	capi, _ := aws.IsCAPIRelease(cluster)
 	if capi {
 		return true, nil
 	}

--- a/pkg/aws/common.go
+++ b/pkg/aws/common.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/label"
+	"github.com/giantswarm/microerror"
 )
 
 const (
@@ -22,8 +23,8 @@ const (
 	// DefaultMasterInstanceType is the default master instance type
 	DefaultMasterInstanceType = "m5.xlarge"
 
-	// LastGSRelease is the last GS release that does not run on CAPI controllers
-	LastGSRelease = "19.0.0"
+	// FirstCAPIRelease is the last GS release that does not run on CAPI controllers
+	FirstCAPIRelease = "20.0.0-v1alpha3"
 
 	// FirstHARelease is the first GS release for AWS that supports HA Masters
 	FirstHARelease = "11.4.0"
@@ -76,9 +77,12 @@ func IsHAVersion(releaseVersion *semver.Version) bool {
 }
 
 // IsCAPIVersion returns whether a given releaseVersion is using CAPI controllers
-func IsCAPIVersion(releaseVersion *semver.Version) bool {
-	GSVersion, _ := semver.New(LastGSRelease)
-	return releaseVersion.GT(*GSVersion)
+func IsCAPIVersion(releaseVersion *semver.Version) (bool, error) {
+	CAPIVersion, err := semver.New(FirstCAPIRelease)
+	if err != nil {
+		return false, microerror.Maskf(parsingFailedError, "unable to get first CAPI release version")
+	}
+	return releaseVersion.GE(*CAPIVersion), nil
 }
 
 // IsVersionLabel returns whether a label is considered a version label

--- a/pkg/aws/common.go
+++ b/pkg/aws/common.go
@@ -4,10 +4,10 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
+	"github.com/giantswarm/microerror"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/label"
-	"github.com/giantswarm/microerror"
 )
 
 const (

--- a/pkg/aws/common.go
+++ b/pkg/aws/common.go
@@ -23,7 +23,7 @@ const (
 	// DefaultMasterInstanceType is the default master instance type
 	DefaultMasterInstanceType = "m5.xlarge"
 
-	// FirstCAPIRelease is the last GS release that does not run on CAPI controllers
+	// FirstCAPIRelease is the first GS release that runs on CAPI controllers
 	FirstCAPIRelease = "20.0.0-v1alpha3"
 
 	// FirstHARelease is the first GS release for AWS that supports HA Masters

--- a/pkg/aws/common.go
+++ b/pkg/aws/common.go
@@ -22,6 +22,9 @@ const (
 	// DefaultMasterInstanceType is the default master instance type
 	DefaultMasterInstanceType = "m5.xlarge"
 
+	// LastGSRelease is the last GS release that does not run on CAPI controllers
+	LastGSRelease = "19.0.0"
+
 	// FirstHARelease is the first GS release for AWS that supports HA Masters
 	FirstHARelease = "11.4.0"
 
@@ -70,6 +73,12 @@ func IsGiantSwarmLabel(label string) bool {
 func IsHAVersion(releaseVersion *semver.Version) bool {
 	HAVersion, _ := semver.New(FirstHARelease)
 	return releaseVersion.GE(*HAVersion)
+}
+
+// IsCAPIVersion returns whether a given releaseVersion is using CAPI controllers
+func IsCAPIVersion(releaseVersion *semver.Version) bool {
+	GSVersion, _ := semver.New(LastGSRelease)
+	return releaseVersion.GT(*GSVersion)
 }
 
 // IsVersionLabel returns whether a label is considered a version label

--- a/pkg/aws/common_fetcher.go
+++ b/pkg/aws/common_fetcher.go
@@ -224,6 +224,13 @@ func FetchNewestReleaseVersion(m *Handler) (*semver.Version, error) {
 			if !IsVersionProductionReady(version) {
 				continue
 			}
+			capi, err := IsCAPIVersion(version)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+			if capi {
+				continue
+			}
 
 			activeReleases = append(activeReleases, *version)
 		}

--- a/pkg/aws/common_fetcher_test.go
+++ b/pkg/aws/common_fetcher_test.go
@@ -78,6 +78,23 @@ func TestNewestReleaseVersion(t *testing.T) {
 			},
 			expectedVersion: "1.2.3",
 		},
+		{
+			// don't take CAPI versions
+			name: "case 1",
+			ctx:  context.Background(),
+
+			releases: []unittest.ReleaseData{
+				{
+					Name:  "v1.2.3",
+					State: releasev1alpha1.StateActive,
+				},
+				{
+					Name:  "v20.0.0-v1alpha3",
+					State: releasev1alpha1.StateActive,
+				},
+			},
+			expectedVersion: "1.2.3",
+		},
 	}
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/pkg/aws/common_handler.go
+++ b/pkg/aws/common_handler.go
@@ -47,6 +47,17 @@ func GetNavailabilityZones(m *Handler, n int, azs []string) []string {
 	return randomAZs
 }
 
+func IsCAPIRelease(meta metav1.Object) (bool, error) {
+	if meta.GetLabels()[label.Release] == "" {
+		return false, nil
+	}
+	releaseVersion, err := ReleaseVersion(meta, []mutator.PatchOperation{})
+	if err != nil {
+		return false, microerror.Maskf(parsingFailedError, "unable to parse release version from object")
+	}
+	return IsCAPIVersion(releaseVersion), nil
+}
+
 func ReleaseVersion(meta metav1.Object, patch []mutator.PatchOperation) (*semver.Version, error) {
 	var version string
 	var ok bool

--- a/pkg/aws/common_handler.go
+++ b/pkg/aws/common_handler.go
@@ -55,7 +55,7 @@ func IsCAPIRelease(meta metav1.Object) (bool, error) {
 	if err != nil {
 		return false, microerror.Maskf(parsingFailedError, "unable to parse release version from object")
 	}
-	return IsCAPIVersion(releaseVersion), nil
+	return IsCAPIVersion(releaseVersion)
 }
 
 func ReleaseVersion(meta metav1.Object, patch []mutator.PatchOperation) (*semver.Version, error) {

--- a/pkg/aws/common_handler_test.go
+++ b/pkg/aws/common_handler_test.go
@@ -27,7 +27,15 @@ func TestCAPIReleaseLabel(t *testing.T) {
 		},
 		{
 			// CAPI Release label is set
-			name: "case 0",
+			name: "case 1",
+			ctx:  context.Background(),
+
+			currentRelease: "20.0.0-v1alpha3",
+			expectedResult: true,
+		},
+		{
+			// CAPI Release label is set
+			name: "case 2",
 			ctx:  context.Background(),
 
 			currentRelease: "20.0.0",
@@ -35,7 +43,7 @@ func TestCAPIReleaseLabel(t *testing.T) {
 		},
 		{
 			// GS Release label is set
-			name: "case 0",
+			name: "case 3",
 			ctx:  context.Background(),
 
 			currentRelease: "14.0.0",

--- a/pkg/aws/common_handler_test.go
+++ b/pkg/aws/common_handler_test.go
@@ -1,0 +1,59 @@
+package aws
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/label"
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/unittest"
+)
+
+func TestCAPIReleaseLabel(t *testing.T) {
+	testCases := []struct {
+		ctx  context.Context
+		name string
+
+		currentRelease string
+		expectedResult bool
+	}{
+		{
+			// Release label is not set
+			name: "case 0",
+			ctx:  context.Background(),
+
+			currentRelease: "",
+			expectedResult: false,
+		},
+		{
+			// CAPI Release label is set
+			name: "case 0",
+			ctx:  context.Background(),
+
+			currentRelease: "20.0.0",
+			expectedResult: true,
+		},
+		{
+			// GS Release label is set
+			name: "case 0",
+			ctx:  context.Background(),
+
+			currentRelease: "14.0.0",
+			expectedResult: false,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			cluster := unittest.DefaultCluster()
+			cluster.SetLabels(map[string]string{label.Release: tc.currentRelease})
+			capi, err := IsCAPIRelease(&cluster)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// check if the result label is as expected
+			if tc.expectedResult != capi {
+				t.Fatalf("expected %v to be equal to %v", tc.expectedResult, capi)
+			}
+		})
+	}
+}

--- a/pkg/aws/machinedeployment/mutate_machinedeployment.go
+++ b/pkg/aws/machinedeployment/mutate_machinedeployment.go
@@ -66,7 +66,10 @@ func (m *Mutator) MutateCreate(request *admissionv1.AdmissionRequest) ([]mutator
 	if _, _, err := mutator.Deserializer.Decode(request.Object.Raw, nil, machineDeployment); err != nil {
 		return nil, microerror.Maskf(parsingFailedError, "unable to parse MachineDeployment: %v", err)
 	}
-	capi, _ := aws.IsCAPIRelease(machineDeployment)
+	capi, err := aws.IsCAPIRelease(machineDeployment)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
 	if capi {
 		return result, nil
 	}

--- a/pkg/aws/machinedeployment/mutate_machinedeployment.go
+++ b/pkg/aws/machinedeployment/mutate_machinedeployment.go
@@ -66,10 +66,7 @@ func (m *Mutator) MutateCreate(request *admissionv1.AdmissionRequest) ([]mutator
 	if _, _, err := mutator.Deserializer.Decode(request.Object.Raw, nil, machineDeployment); err != nil {
 		return nil, microerror.Maskf(parsingFailedError, "unable to parse MachineDeployment: %v", err)
 	}
-	capi, err := aws.IsCAPIRelease(machineDeployment)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
+	capi, _ := aws.IsCAPIRelease(machineDeployment)
 	if capi {
 		return result, nil
 	}

--- a/pkg/aws/machinedeployment/mutate_machinedeployment.go
+++ b/pkg/aws/machinedeployment/mutate_machinedeployment.go
@@ -66,6 +66,13 @@ func (m *Mutator) MutateCreate(request *admissionv1.AdmissionRequest) ([]mutator
 	if _, _, err := mutator.Deserializer.Decode(request.Object.Raw, nil, machineDeployment); err != nil {
 		return nil, microerror.Maskf(parsingFailedError, "unable to parse MachineDeployment: %v", err)
 	}
+	capi, err := aws.IsCAPIRelease(machineDeployment)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	if capi {
+		return result, nil
+	}
 
 	patch, err = m.MutateReleaseVersion(*machineDeployment)
 	if err != nil {

--- a/pkg/aws/machinedeployment/validate_machinedeployment.go
+++ b/pkg/aws/machinedeployment/validate_machinedeployment.go
@@ -49,7 +49,10 @@ func (v *Validator) ValidateCreate(request *admissionv1.AdmissionRequest) (bool,
 	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, &machineDeployment); err != nil {
 		return false, microerror.Maskf(parsingFailedError, "unable to parse machinedeployment: %v", err)
 	}
-	capi, _ := aws.IsCAPIRelease(&machineDeployment)
+	capi, err := aws.IsCAPIRelease(&machineDeployment)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
 	if capi {
 		return true, nil
 	}

--- a/pkg/aws/machinedeployment/validate_machinedeployment.go
+++ b/pkg/aws/machinedeployment/validate_machinedeployment.go
@@ -49,10 +49,7 @@ func (v *Validator) ValidateCreate(request *admissionv1.AdmissionRequest) (bool,
 	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, &machineDeployment); err != nil {
 		return false, microerror.Maskf(parsingFailedError, "unable to parse machinedeployment: %v", err)
 	}
-	capi, err := aws.IsCAPIRelease(&machineDeployment)
-	if err != nil {
-		return false, microerror.Mask(err)
-	}
+	capi, _ := aws.IsCAPIRelease(&machineDeployment)
 	if capi {
 		return true, nil
 	}

--- a/pkg/aws/machinedeployment/validate_machinedeployment.go
+++ b/pkg/aws/machinedeployment/validate_machinedeployment.go
@@ -49,6 +49,13 @@ func (v *Validator) ValidateCreate(request *admissionv1.AdmissionRequest) (bool,
 	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, &machineDeployment); err != nil {
 		return false, microerror.Maskf(parsingFailedError, "unable to parse machinedeployment: %v", err)
 	}
+	capi, err := aws.IsCAPIRelease(&machineDeployment)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+	if capi {
+		return true, nil
+	}
 
 	err = v.ValidateCluster(machineDeployment)
 	if err != nil {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/16119
This just skips Clusters and Machinedeployments that are in a CAPI release version. We might want to refine it more in the future.