### PR TITLE
node-termination-by-defualt-from-15-0-0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dylanmei/iso8601 v0.1.0
 	github.com/dyson/certman v0.2.1
 	github.com/giantswarm/apiextensions/v2 v2.6.2
-	github.com/giantswarm/apiextensions/v3 v3.23.0
+	github.com/giantswarm/apiextensions/v3 v3.25.0
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/k8sclient/v5 v5.11.0
 	github.com/giantswarm/microerror v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/giantswarm/apiextensions/v2 v2.6.2 h1:ECdw6G5QCr5TN95SIFtD63PfNVS7vBnPcreqqFGIFh4=
 github.com/giantswarm/apiextensions/v2 v2.6.2/go.mod h1:/qSx5jA2F5um0ipvVDMZJz+rJqsPZewzz4jjMXkXYFw=
 github.com/giantswarm/apiextensions/v3 v3.18.1/go.mod h1:N4SS083wjVR3GEL/pqWycva4yUtYrlU5lUKhRtZJ7EY=
-github.com/giantswarm/apiextensions/v3 v3.23.0 h1:kbzkkB+xpw6l0wGp7pRtAg3e33DZVnykDgz8i7EbM+A=
-github.com/giantswarm/apiextensions/v3 v3.23.0/go.mod h1:JpgKjjHgdrrgj3QhwJdyCYbO5fqfsRWIul6A6UaiyFk=
+github.com/giantswarm/apiextensions/v3 v3.25.0 h1:BxZ6IOpK3C/efhqIGpO4LQleiOsJ3UFgK4bHBqqiEuY=
+github.com/giantswarm/apiextensions/v3 v3.25.0/go.mod h1:JpgKjjHgdrrgj3QhwJdyCYbO5fqfsRWIul6A6UaiyFk=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=
 github.com/giantswarm/backoff v0.2.0/go.mod h1:Z3WRsFilSJ5H5VlFa4XhraoPr+9pmZgYasoY2OSfNOk=
 github.com/giantswarm/cluster-api v0.3.13-gs h1:ZgOMYkSuM1KnRmdDkPTfYj8G+Bdn6K1+sI0RnsPoBSc=

--- a/pkg/aws/awscluster/mutate_awscluster.go
+++ b/pkg/aws/awscluster/mutate_awscluster.go
@@ -472,7 +472,7 @@ func (m *Mutator) MutateAnnotationNodeTerminateUnhealthy(awsCluster infrastructu
 				aws.AnnotationAlphaNodeTerminateUnhealthy,
 				annotation.NodeTerminateUnhealthy),
 			)
-			patch := mutator.PatchAdd(fmt.Sprintf("/metadata/annotations"), awsCluster.Annotations)
+			patch := mutator.PatchAdd("/metadata/annotations", awsCluster.Annotations)
 			result = append(result, patch)
 		}
 	}

--- a/pkg/aws/awscluster/mutate_awscluster.go
+++ b/pkg/aws/awscluster/mutate_awscluster.go
@@ -474,7 +474,11 @@ func (m *Mutator) MutateAnnotationNodeTerminateUnhealthy(awsCluster infrastructu
 			)
 			patch := mutator.PatchAdd("/metadata/annotations", awsCluster.Annotations)
 			result = append(result, patch)
+		} else {
+			m.Log("level", "debug", "message", fmt.Sprintf("release GE 15.0.0, but no annotation %s found (annotations %#v), skipping  upgrade", aws.AnnotationAlphaNodeTerminateUnhealthy, awsCluster.GetAnnotations()))
 		}
+	} else {
+		m.Log("level", "debug", "message", fmt.Sprintf("release '%s' is not GE 15.0.0, skipping anotation upgrade", release))
 	}
 	return result, nil
 }

--- a/pkg/aws/awscluster/mutate_awscluster.go
+++ b/pkg/aws/awscluster/mutate_awscluster.go
@@ -24,6 +24,11 @@ import (
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/mutator"
 )
 
+const (
+	stringTrue  = "true"
+	stringFalse = "false"
+)
+
 type Config struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
@@ -456,10 +461,10 @@ func (m *Mutator) MutateAnnotationNodeTerminateUnhealthy(awsCluster infrastructu
 			delete(awsCluster.Annotations, aws.AnnotationAlphaNodeTerminateUnhealthy)
 
 			// set new annotation, any value except 'false' is considered as true
-			if terminateUnhealthy == "false" {
-				awsCluster.Annotations[annotation.NodeTerminateUnhealthy] = "false"
+			if terminateUnhealthy == stringFalse {
+				awsCluster.Annotations[annotation.NodeTerminateUnhealthy] = stringFalse
 			} else {
-				awsCluster.Annotations[annotation.NodeTerminateUnhealthy] = "true"
+				awsCluster.Annotations[annotation.NodeTerminateUnhealthy] = stringTrue
 			}
 
 			m.Log("level", "debug", "message", fmt.Sprintf("AWSCluster annotation '%s' migrated to '%s'.",

--- a/pkg/aws/awscluster/mutate_awscluster.go
+++ b/pkg/aws/awscluster/mutate_awscluster.go
@@ -453,7 +453,7 @@ func (m *Mutator) MutateAnnotationNodeTerminateUnhealthy(awsCluster infrastructu
 	}
 
 	// new annotation is available from release > 15.x.x
-	release15 := semver.MustParse("v15.0.0")
+	release15 := semver.MustParse("15.0.0")
 	if release.GE(release15) {
 		//load the old alpha annotation
 		if terminateUnhealthy, ok := awsCluster.GetAnnotations()[aws.AnnotationAlphaNodeTerminateUnhealthy]; ok {

--- a/pkg/aws/awscluster/mutate_awscluster.go
+++ b/pkg/aws/awscluster/mutate_awscluster.go
@@ -460,6 +460,7 @@ func (m *Mutator) MutateAnnotationNodeTerminateUnhealthy(awsCluster infrastructu
 			// clean the old annotation
 			delete(awsCluster.Annotations, aws.AnnotationAlphaNodeTerminateUnhealthy)
 
+			//var anannotationValue string
 			// set new annotation, any value except 'false' is considered as true
 			if terminateUnhealthy == stringFalse {
 				awsCluster.Annotations[annotation.NodeTerminateUnhealthy] = stringFalse
@@ -471,7 +472,7 @@ func (m *Mutator) MutateAnnotationNodeTerminateUnhealthy(awsCluster infrastructu
 				aws.AnnotationAlphaNodeTerminateUnhealthy,
 				annotation.NodeTerminateUnhealthy),
 			)
-			patch := mutator.PatchAdd("/metadata/annotations", awsCluster.Annotations)
+			patch := mutator.PatchAdd(fmt.Sprintf("/metadata/annotations"), awsCluster.Annotations)
 			result = append(result, patch)
 		}
 	}

--- a/pkg/aws/awscluster/mutate_awscluster.go
+++ b/pkg/aws/awscluster/mutate_awscluster.go
@@ -453,7 +453,7 @@ func (m *Mutator) MutateAnnotationNodeTerminateUnhealthy(awsCluster infrastructu
 	}
 
 	// new annotation is available from release > 15.x.x
-	release15 := semver.MustParse("15.0.0")
+	release15 := semver.MustParse("14.99.99")
 	if release.GE(release15) {
 		//load the old alpha annotation
 		if terminateUnhealthy, ok := awsCluster.GetAnnotations()[aws.AnnotationAlphaNodeTerminateUnhealthy]; ok {

--- a/pkg/aws/awscluster/mutate_awscluster.go
+++ b/pkg/aws/awscluster/mutate_awscluster.go
@@ -444,6 +444,7 @@ func (m *Mutator) MutateRegion(awsCluster infrastructurev1alpha2.AWSCluster) ([]
 }
 
 //MutateAnnotationNodeTerminateUnhealthy migrate NodeTerminateUnhealthy annotations from alpha to stable in case it is configured.
+// this migration code can be removed once all AWS clusters are on release 15.0.0 or newer
 func (m *Mutator) MutateAnnotationNodeTerminateUnhealthy(awsCluster infrastructurev1alpha2.AWSCluster) ([]mutator.PatchOperation, error) {
 	var result []mutator.PatchOperation
 
@@ -475,9 +476,11 @@ func (m *Mutator) MutateAnnotationNodeTerminateUnhealthy(awsCluster infrastructu
 			patch := mutator.PatchAdd("/metadata/annotations", awsCluster.Annotations)
 			result = append(result, patch)
 		} else {
+			// debug code, remove before merge
 			m.Log("level", "debug", "message", fmt.Sprintf("release GE 15.0.0, but no annotation %s found (annotations %#v), skipping  upgrade", aws.AnnotationAlphaNodeTerminateUnhealthy, awsCluster.GetAnnotations()))
 		}
 	} else {
+		// debug code, remove before merge
 		m.Log("level", "debug", "message", fmt.Sprintf("release '%s' is not GE 15.0.0, skipping anotation upgrade", release))
 	}
 	return result, nil

--- a/pkg/aws/awscluster/validate_awscluster.go
+++ b/pkg/aws/awscluster/validate_awscluster.go
@@ -70,6 +70,11 @@ func (v *Validator) Validate(request *admissionv1.AdmissionRequest) (bool, error
 		return false, microerror.Mask(err)
 	}
 
+	err = v.AWSClusterAnnotationNodeTerminateUnhealthy(awsCluster)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
 	return true, nil
 }
 
@@ -131,6 +136,22 @@ func (v *Validator) AWSClusterAnnotationPauseTimeIsValid(awsCluster infrastructu
 			return microerror.Maskf(notAllowedError, fmt.Sprintf("AWSCluster annotation '%s' value '%s' is not valid. Value must be in ISO 8601 duration format and cannot be bigger than 1 hour.",
 				aws.AnnotationUpdatePauseTime,
 				maxBatchSize),
+			)
+		}
+	}
+	return nil
+}
+
+func (v *Validator) AWSClusterAnnotationNodeTerminateUnhealthy(awsCluster infrastructurev1alpha2.AWSCluster) error {
+	if terminateUnhealthy, ok := awsCluster.GetAnnotations()[annotation.NodeTerminateUnhealthy]; ok {
+		if !(terminateUnhealthy == "true" || terminateUnhealthy == "false") {
+			v.logger.Log("level", "debug", "message", fmt.Sprintf("AWSCluster annotation '%s' value '%s' is not valid. Value must be either '\"true\"' or '\"false\"'.",
+				annotation.NodeTerminateUnhealthy,
+				terminateUnhealthy),
+			)
+			return microerror.Maskf(notAllowedError, fmt.Sprintf("AWSCluster annotation '%s' value '%s' is not valid. Value must be either '\"true\"' or '\"false\"'.",
+				annotation.NodeTerminateUnhealthy,
+				terminateUnhealthy),
 			)
 		}
 	}

--- a/pkg/aws/cluster/mutate_cluster.go
+++ b/pkg/aws/cluster/mutate_cluster.go
@@ -174,7 +174,7 @@ func (m *Mutator) MutateReleaseVersion(cluster capiv1alpha2.Cluster) ([]mutator.
 	m.Log("level", "debug", "message", fmt.Sprintf("Label %s is not set and will be defaulted to newest version %s.",
 		label.Release,
 		newestRelease.String()))
-	patch := mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", aws.EscapeJSONPatchString(label.Release)), newestRelease.String())
+	patch := mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", key.EscapeJSONPatchString(label.Release)), newestRelease.String())
 	result = append(result, patch)
 
 	return result, nil

--- a/pkg/aws/cluster/mutate_test.go
+++ b/pkg/aws/cluster/mutate_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/giantswarm/micrologger/microloggertest"
 
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/aws"
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/key"
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/label"
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/mutator"
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/unittest"
@@ -70,7 +71,7 @@ func TestMutateOperatorVersion(t *testing.T) {
 			}
 			// parse patches
 			for _, p := range patch {
-				if p.Path == fmt.Sprintf("/metadata/labels/%s", aws.EscapeJSONPatchString(label.ClusterOperatorVersion)) {
+				if p.Path == fmt.Sprintf("/metadata/labels/%s", key.EscapeJSONPatchString(label.ClusterOperatorVersion)) {
 					updatedOperator = p.Value.(string)
 				}
 			}

--- a/pkg/aws/cluster/mutate_test.go
+++ b/pkg/aws/cluster/mutate_test.go
@@ -142,7 +142,7 @@ func TestMutateReleaseUpdate(t *testing.T) {
 			}
 			// parse patches
 			for _, p := range patch {
-				if p.Path == fmt.Sprintf("/metadata/labels/%s", aws.EscapeJSONPatchString(label.ClusterOperatorVersion)) {
+				if p.Path == fmt.Sprintf("/metadata/labels/%s", key.EscapeJSONPatchString(label.ClusterOperatorVersion)) {
 					updatedOperator = p.Value.(string)
 				}
 			}

--- a/pkg/aws/common.go
+++ b/pkg/aws/common.go
@@ -39,7 +39,7 @@ const (
 	AnnotationUpdateMaxBatchSize = "alpha.aws.giantswarm.io/update-max-batch-size"
 	AnnotationUpdatePauseTime    = "alpha.aws.giantswarm.io/update-pause-time"
 
-	AnnotationAlphaNodeTerminateUnhealthy = ""
+	AnnotationAlphaNodeTerminateUnhealthy = "alpha.aws.giantswarm.io/terminate-unhealthy"
 )
 
 // DefaultCredentialSecret returns the default credentials for clusters

--- a/pkg/aws/common.go
+++ b/pkg/aws/common.go
@@ -38,6 +38,8 @@ const (
 	// once the service is migrate to apiextensions v3
 	AnnotationUpdateMaxBatchSize = "alpha.aws.giantswarm.io/update-max-batch-size"
 	AnnotationUpdatePauseTime    = "alpha.aws.giantswarm.io/update-pause-time"
+
+	AnnotationAlphaNodeTerminateUnhealthy = ""
 )
 
 // DefaultCredentialSecret returns the default credentials for clusters

--- a/pkg/aws/common_handler.go
+++ b/pkg/aws/common_handler.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/blang/semver"
@@ -14,6 +13,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/key"
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/label"
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/mutator"
 )
@@ -63,7 +63,7 @@ func ReleaseVersion(meta metav1.Object, patch []mutator.PatchOperation) (*semver
 	var ok bool
 	// check first if the release version is contained in a patch
 	for _, p := range patch {
-		if p.Path == fmt.Sprintf("/metadata/labels/%s", EscapeJSONPatchString(label.Release)) {
+		if p.Path == fmt.Sprintf("/metadata/labels/%s", key.EscapeJSONPatchString(label.Release)) {
 			version = p.Value.(string)
 			return semver.New(version)
 		}
@@ -74,12 +74,4 @@ func ReleaseVersion(meta metav1.Object, patch []mutator.PatchOperation) (*semver
 		return nil, microerror.Maskf(parsingFailedError, "unable to get release version from Object %s", meta.GetName())
 	}
 	return semver.New(version)
-}
-
-// Ensure the needed escapes are in place. See https://tools.ietf.org/html/rfc6901#section-3 .
-func EscapeJSONPatchString(input string) string {
-	input = strings.ReplaceAll(input, "~", "~0")
-	input = strings.ReplaceAll(input, "/", "~1")
-
-	return input
 }

--- a/pkg/aws/common_mutator.go
+++ b/pkg/aws/common_mutator.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/key"
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/mutator"
 )
 
@@ -28,7 +29,7 @@ func MutateLabelFromAWSCluster(m *Handler, meta metav1.Object, awsCluster infras
 		label,
 		value,
 		awsCluster.GetName()))
-	patch := mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", EscapeJSONPatchString(label)), value)
+	patch := mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", key.EscapeJSONPatchString(label)), value)
 	result = append(result, patch)
 
 	return result, nil
@@ -50,7 +51,7 @@ func MutateLabelFromCluster(m *Handler, meta metav1.Object, cluster capiv1alpha2
 		label,
 		value,
 		cluster.GetName()))
-	patch := mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", EscapeJSONPatchString(label)), value)
+	patch := mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", key.EscapeJSONPatchString(label)), value)
 	result = append(result, patch)
 
 	return result, nil
@@ -71,7 +72,7 @@ func MutateLabelFromRelease(m *Handler, meta metav1.Object, release releasev1alp
 		label,
 		value,
 		release.GetName()))
-	patch := mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", EscapeJSONPatchString(label)), value)
+	patch := mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", key.EscapeJSONPatchString(label)), value)
 	result = append(result, patch)
 
 	return result, nil

--- a/pkg/aws/common_mutator_test.go
+++ b/pkg/aws/common_mutator_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/giantswarm/micrologger/microloggertest"
 
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/key"
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/label"
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/mutator"
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/unittest"
@@ -59,7 +60,7 @@ func TestLabelFromCluster(t *testing.T) {
 			}
 			// parse patches
 			for _, p := range patch {
-				if p.Path == fmt.Sprintf("/metadata/labels/%s", EscapeJSONPatchString(label.Release)) {
+				if p.Path == fmt.Sprintf("/metadata/labels/%s", key.EscapeJSONPatchString(label.Release)) {
 					updatedRelease = p.Value.(string)
 				}
 			}

--- a/pkg/aws/common_mutator_test.go
+++ b/pkg/aws/common_mutator_test.go
@@ -118,7 +118,7 @@ func TestLabelFromAWSCluster(t *testing.T) {
 			}
 			// parse patches
 			for _, p := range patch {
-				if p.Path == fmt.Sprintf("/metadata/labels/%s", EscapeJSONPatchString(label.AWSOperatorVersion)) {
+				if p.Path == fmt.Sprintf("/metadata/labels/%s", key.EscapeJSONPatchString(label.AWSOperatorVersion)) {
 					updatedOperator = p.Value.(string)
 				}
 			}
@@ -176,7 +176,7 @@ func TestLabelFromRelease(t *testing.T) {
 			}
 			// parse patches
 			for _, p := range patch {
-				if p.Path == fmt.Sprintf("/metadata/labels/%s", EscapeJSONPatchString(label.AWSOperatorVersion)) {
+				if p.Path == fmt.Sprintf("/metadata/labels/%s", key.EscapeJSONPatchString(label.AWSOperatorVersion)) {
 					updatedOperator = p.Value.(string)
 				}
 			}

--- a/pkg/key/common.go
+++ b/pkg/key/common.go
@@ -1,8 +1,9 @@
 package key
 
 import (
-	"github.com/giantswarm/aws-admission-controller/v2/pkg/label"
 	"strings"
+
+	"github.com/giantswarm/aws-admission-controller/v2/pkg/label"
 )
 
 func AWSOperator(getter LabelsGetter) string {

--- a/pkg/key/common.go
+++ b/pkg/key/common.go
@@ -2,6 +2,7 @@ package key
 
 import (
 	"github.com/giantswarm/aws-admission-controller/v2/pkg/label"
+	"strings"
 )
 
 func AWSOperator(getter LabelsGetter) string {
@@ -29,4 +30,12 @@ func MachineDeployment(getter LabelsGetter) string {
 
 func Organization(getter LabelsGetter) string {
 	return getter.GetLabels()[label.Organization]
+}
+
+// Ensure the needed escapes are in place. See https://tools.ietf.org/html/rfc6901#section-3 .
+func EscapeJSONPatchString(input string) string {
+	input = strings.ReplaceAll(input, "~", "~0")
+	input = strings.ReplaceAll(input, "/", "~1")
+
+	return input
 }


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/16843

add validating webhook to allow only values `true` or `false` for the new annotation

add mutating webhook to migrate from old annotation (if present)
as in the previous alpha version, the annotation could be anything to enable the feature now we set the value to `true` if there is anything except `false`

code could be removed once all clusters are on 15.0.0