### PR TITLE
v1alpha3 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `cluster.x-k8s.io/cluster-name` for `v1alpha3` CAPI CR's.
+
+### Changed
+
+- Default `clusterName` for `MachineDeployments` if empty.
+
+### Fixed
+
+- Fixed `infrastrutureRef` in /spec/template/spec for `MachindeDeployments`.
+
 ## [3.0.0] - 2021-08-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `infrastrutureRef` in /spec/template/spec for `MachindeDeployments`.
+- Fixed `infrastrutureRef` in /spec/template/spec for `MachineDeployments`.
 
 ## [3.0.0] - 2021-08-03
 

--- a/pkg/aws/v1alpha3/cluster/mutate_cluster.go
+++ b/pkg/aws/v1alpha3/cluster/mutate_cluster.go
@@ -98,7 +98,7 @@ func (m *Mutator) MutateCreate(request *admissionv1.AdmissionRequest) ([]mutator
 	}
 	result = append(result, patch...)
 
-	patch = m.MutateCAPILabel(*cluster)
+	patch = aws.MutateCAPILabel(&aws.Handler{K8sClient: m.k8sClient, Logger: m.logger}, cluster)
 	result = append(result, patch...)
 
 	patch, err = m.MutateInfraRef(*cluster, releaseVersion)
@@ -145,7 +145,7 @@ func (m *Mutator) MutateUpdate(request *admissionv1.AdmissionRequest) ([]mutator
 		return nil, microerror.Maskf(parsingFailedError, "unable to parse release version from Cluster")
 	}
 
-	patch = m.MutateCAPILabel(*cluster)
+	patch = aws.MutateCAPILabel(&aws.Handler{K8sClient: m.k8sClient, Logger: m.logger}, cluster)
 	result = append(result, patch...)
 
 	patch, err = m.MutateInfraRef(*cluster, releaseVersion)

--- a/pkg/aws/v1alpha3/cluster/mutate_cluster.go
+++ b/pkg/aws/v1alpha3/cluster/mutate_cluster.go
@@ -269,7 +269,7 @@ func (m *Mutator) MutateInfraRef(cluster capiv1alpha3.Cluster, releaseVersion *s
 func (m *Mutator) MutateCAPILabel(cluster capiv1alpha3.Cluster) []mutator.PatchOperation {
 	var result []mutator.PatchOperation
 
-	if cluster.Labels[capiv1alpha3.ClusterLabelName] != "" {
+	if cluster.Labels[capiv1alpha3.ClusterLabelName] == "" {
 		// mutate the cluster label name
 		m.Log("level", "debug", "message", fmt.Sprintf("Label %s is not set and will be defaulted to %s.",
 			capiv1alpha3.ClusterLabelName, cluster.ObjectMeta.Name))

--- a/pkg/aws/v1alpha3/cluster/mutate_cluster.go
+++ b/pkg/aws/v1alpha3/cluster/mutate_cluster.go
@@ -265,18 +265,3 @@ func (m *Mutator) MutateInfraRef(cluster capiv1alpha3.Cluster, releaseVersion *s
 	}
 	return nil, nil
 }
-
-func (m *Mutator) MutateCAPILabel(cluster capiv1alpha3.Cluster) []mutator.PatchOperation {
-	var result []mutator.PatchOperation
-
-	if cluster.Labels[capiv1alpha3.ClusterLabelName] == "" {
-		// mutate the cluster label name
-		m.Log("level", "debug", "message", fmt.Sprintf("Label %s is not set and will be defaulted to %s.",
-			capiv1alpha3.ClusterLabelName, cluster.ObjectMeta.Name))
-
-		patch := mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", aws.EscapeJSONPatchString(capiv1alpha3.ClusterLabelName)), cluster.ObjectMeta.Name)
-		result = append(result, patch)
-	}
-
-	return result
-}

--- a/pkg/aws/v1alpha3/machinedeployment/mutate_machinedeployment.go
+++ b/pkg/aws/v1alpha3/machinedeployment/mutate_machinedeployment.go
@@ -210,7 +210,7 @@ func (m *Mutator) MutateInfraRef(machineDeployment capiv1alpha3.MachineDeploymen
 func (m *Mutator) MutateCAPILabel(md capiv1alpha3.MachineDeployment) []mutator.PatchOperation {
 	var result []mutator.PatchOperation
 
-	if md.Labels[capiv1alpha3.ClusterLabelName] != "" {
+	if md.Labels[capiv1alpha3.ClusterLabelName] == "" {
 		// mutate the cluster label name
 		m.Log("level", "debug", "message", fmt.Sprintf("Label %s is not set and will be defaulted to %s.",
 			capiv1alpha3.ClusterLabelName, md.Labels[label.Cluster]))

--- a/pkg/aws/v1alpha3/machinedeployment/mutate_machinedeployment_infraref_update_test.go
+++ b/pkg/aws/v1alpha3/machinedeployment/mutate_machinedeployment_infraref_update_test.go
@@ -76,7 +76,7 @@ func TestMutateInfraRefUpdate(t *testing.T) {
 
 			// parse patches
 			for _, p := range patch {
-				if p.Path == "/spec/infrastructureRef" {
+				if p.Path == "/spec/template/spec/infrastructureRef" {
 					apiVersion = p.Value.(*v1.ObjectReference).APIVersion
 				}
 			}


### PR DESCRIPTION
### Added

- Add `cluster.x-k8s.io/cluster-name` for `v1alpha3` CAPI CR's.

### Changed

- Default `clusterName` for `MachineDeployments` if empty.

### Fixed

- Fixed `infrastrutureRef` in /spec/template/spec for `MachindeDeployments`.
