### PR TITLE
add cluster-name label for all CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `cluster.x-k8s.io/cluster-name` for all CRs.
+
 ## [3.4.0] - 2021-09-28
 
 ### Added

--- a/pkg/aws/v1alpha3/awscluster/mutate_awscluster.go
+++ b/pkg/aws/v1alpha3/awscluster/mutate_awscluster.go
@@ -99,6 +99,9 @@ func (m *Mutator) MutateCreate(request *admissionv1.AdmissionRequest) ([]mutator
 	}
 	result = append(result, patch...)
 
+	patch = aws.MutateCAPILabel(&aws.Handler{K8sClient: m.k8sClient, Logger: m.logger}, awsCluster)
+	result = append(result, patch...)
+
 	patch, err = m.MutateCredential(*awsCluster)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -173,6 +176,9 @@ func (m *Mutator) MutateUpdate(request *admissionv1.AdmissionRequest) ([]mutator
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
+	result = append(result, patch...)
+
+	patch = aws.MutateCAPILabel(&aws.Handler{K8sClient: m.k8sClient, Logger: m.logger}, awsCluster)
 	result = append(result, patch...)
 
 	patch, err = m.MutateCredential(*awsCluster)

--- a/pkg/aws/v1alpha3/awscontrolplane/mutate_awscontrolplane.go
+++ b/pkg/aws/v1alpha3/awscontrolplane/mutate_awscontrolplane.go
@@ -85,6 +85,9 @@ func (m *Mutator) MutateCreate(request *admissionv1.AdmissionRequest) ([]mutator
 	}
 	result = append(result, patch...)
 
+	patch = aws.MutateCAPILabel(&aws.Handler{K8sClient: m.k8sClient, Logger: m.logger}, awsControlPlaneCR)
+	result = append(result, patch...)
+
 	patch, err = m.MutateOperatorVersion(*awsControlPlaneCR)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -141,6 +144,9 @@ func (m *Mutator) MutateUpdate(request *admissionv1.AdmissionRequest) ([]mutator
 	if err != nil {
 		return nil, microerror.Maskf(parsingFailedError, "unable to parse release version from AWSControlPlane")
 	}
+
+	patch = aws.MutateCAPILabel(&aws.Handler{K8sClient: m.k8sClient, Logger: m.logger}, awsControlPlaneCR)
+	result = append(result, patch...)
 
 	// We try to fetch the G8sControlPlane belonging to the AWSControlPlane here.
 	replicas := 0

--- a/pkg/aws/v1alpha3/awsmachinedeployment/mutate_awsmachinedeployment.go
+++ b/pkg/aws/v1alpha3/awsmachinedeployment/mutate_awsmachinedeployment.go
@@ -88,6 +88,9 @@ func (m *Mutator) MutateCreate(request *admissionv1.AdmissionRequest) ([]mutator
 	}
 	result = append(result, patch...)
 
+	patch = aws.MutateCAPILabel(&aws.Handler{K8sClient: m.k8sClient, Logger: m.logger}, awsMachineDeploymentNewCR)
+	result = append(result, patch...)
+
 	patch, err = m.MutateReleaseVersion(*awsMachineDeploymentNewCR)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -122,6 +125,9 @@ func (m *Mutator) MutateUpdate(request *admissionv1.AdmissionRequest) ([]mutator
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
+	result = append(result, patch...)
+
+	patch = aws.MutateCAPILabel(&aws.Handler{K8sClient: m.k8sClient, Logger: m.logger}, awsMachineDeploymentNewCR)
 	result = append(result, patch...)
 
 	return result, nil

--- a/pkg/aws/v1alpha3/awsmachinedeployment/mutate_awsmachinedeployment_test.go
+++ b/pkg/aws/v1alpha3/awsmachinedeployment/mutate_awsmachinedeployment_test.go
@@ -45,6 +45,7 @@ func TestAWSMachineDeploymentAdmit(t *testing.T) {
 			fakeK8sClient := unittest.FakeK8sClient()
 			mutator := &Mutator{
 				k8sClient: fakeK8sClient,
+				logger:    microloggertest.New(),
 			}
 
 			// create AWSMachineDeployment

--- a/pkg/aws/v1alpha3/g8scontrolplane/mutate_g8scontrolplane.go
+++ b/pkg/aws/v1alpha3/g8scontrolplane/mutate_g8scontrolplane.go
@@ -109,6 +109,9 @@ func (m *Mutator) MutateUpdate(request *admissionv1.AdmissionRequest) ([]mutator
 	}
 	result = append(result, patch...)
 
+	patch = aws.MutateCAPILabel(&aws.Handler{K8sClient: m.k8sClient, Logger: m.logger}, g8sControlPlaneNewCR)
+	result = append(result, patch...)
+
 	return result, nil
 }
 
@@ -162,6 +165,9 @@ func (m *Mutator) MutateCreate(request *admissionv1.AdmissionRequest) ([]mutator
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
+	result = append(result, patch...)
+
+	patch = aws.MutateCAPILabel(&aws.Handler{K8sClient: m.k8sClient, Logger: m.logger}, g8sControlPlaneCR)
 	result = append(result, patch...)
 
 	return result, nil


### PR DESCRIPTION
This makes sure that the upstream cluster-name label is added on all resources.
towards https://github.com/giantswarm/giantswarm/issues/19683