### PR TITLE
allow ASG max set to 0 if ASG min is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow setting ASG max scaling to 0 if ASG min is also set to 0.
+
 ## [3.6.0] - 2021-11-26
 
 ### Added

--- a/pkg/aws/v1alpha3/awsmachinedeployment/validate_awsmachinedeployment.go
+++ b/pkg/aws/v1alpha3/awsmachinedeployment/validate_awsmachinedeployment.go
@@ -290,10 +290,6 @@ func (v *Validator) MachineDeploymentScaling(md infrastructurev1alpha3.AWSMachin
 	min := md.Spec.NodePool.Scaling.Min
 	max := md.Spec.NodePool.Scaling.Max
 
-	if max == 0 {
-		return microerror.Maskf(notAllowedError, "AWSMachineDeployment.Spec.Scaling.Max must not be 0.")
-	}
-
 	if min > max {
 		return microerror.Maskf(notAllowedError, "AWSMachineDeployment.Spec.Scaling.Min must not be greater that AWSMachineDeployment.Spec.Scaling.Max.")
 	}

--- a/pkg/aws/v1alpha3/awsmachinedeployment/validate_awsmachinedeployment_test.go
+++ b/pkg/aws/v1alpha3/awsmachinedeployment/validate_awsmachinedeployment_test.go
@@ -349,7 +349,7 @@ func TestValidateMachineDeploymentScaling(t *testing.T) {
 				Min: 0,
 				Max: 0,
 			},
-			matcher: IsNotAllowed,
+			matcher: nil,
 		},
 		{
 			// case 3


### PR DESCRIPTION
We should allow adjusting the max setting for an ASG in case of a scale down event. However I'd propose setting the ASG min to 0 as well would be a good idea.