### PR TITLE
Handle patch updates with empty release value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Handle update patch with empty version string
+
 ## [3.6.2] - 2021-12-01
 
 ### Fixed

--- a/pkg/aws/v1alpha3/common_handler.go
+++ b/pkg/aws/v1alpha3/common_handler.go
@@ -65,7 +65,11 @@ func ReleaseVersion(meta metav1.Object, patch []mutator.PatchOperation) (*semver
 	for _, p := range patch {
 		if p.Path == fmt.Sprintf("/metadata/labels/%s", EscapeJSONPatchString(label.Release)) {
 			version = p.Value.(string)
-			return semver.New(version)
+			if version != "" {
+				return semver.New(version)
+			} else {
+				break
+			}
 		}
 	}
 	// otherwise check the labels


### PR DESCRIPTION
This goes part-way to resolving some of the gitops issues. 

As k-gs template generates resources (e.g. machinedeployment) without the release value populated and instead relies on the mutating webhook to fill it in any additional applies of the same manifest would fail as the version is empty.

This change defaults back to the version already on the resource label if the value is an empty string.