### PR TITLE
Validate Cilium CNI

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -13,3 +13,7 @@ sonatype-2021-3619 until=2022-08-21
 
 # Negroni - no fix yet
 sonatype-2021-1485 until=2022-08-01
+
+CVE-2022-29153 until=2022-11-01
+CVE-2022-24687 until=2022-11-01
+sonatype-2021-1485 until=2022-11-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Validate Cilium CNI.
+- Validate `cilium.giantswarm.io/pod-cidr` annotation is present and valid while upgrading from v17 to v18.
 
 ## [4.1.0] - 2022-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Validate Cilium CNI.
+
 ## [4.1.0] - 2022-07-22
 
 ## [4.0.3] - 2022-06-15

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/giantswarm/apiextensions/v6 v6.0.0
 	github.com/giantswarm/backoff v1.0.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8smetadata v0.10.0
+	github.com/giantswarm/k8smetadata v0.12.0
 	github.com/giantswarm/microerror v0.4.0
 	github.com/giantswarm/micrologger v0.6.0
 	github.com/giantswarm/release-operator/v3 v3.2.0

--- a/go.sum
+++ b/go.sum
@@ -371,8 +371,8 @@ github.com/giantswarm/k8sclient/v6 v6.1.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
 github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
-github.com/giantswarm/k8smetadata v0.10.0 h1:+gQPtyrQBRkRHk/gAGaRxzcS6mbiZ6Czx5l4GHji3qo=
-github.com/giantswarm/k8smetadata v0.10.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
+github.com/giantswarm/k8smetadata v0.12.0 h1:YmCGD0jhGJ+35h0BgkEnIaOSR24Mg4I+F0jPOa1+JUY=
+github.com/giantswarm/k8smetadata v0.12.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/microendpoint v0.2.0/go.mod h1:SSkSp4Q4iSW7vwkil+/E3IXy9Q8To8vXmT5VCg24RDg=
 github.com/giantswarm/microerror v0.2.0/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=
 github.com/giantswarm/microerror v0.2.1/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=

--- a/pkg/aws/v1alpha3/awscluster/validate_awscluster.go
+++ b/pkg/aws/v1alpha3/awscluster/validate_awscluster.go
@@ -161,7 +161,7 @@ func (v *Validator) Cilium(awsCluster infrastructurev1alpha3.AWSCluster) error {
 
 	_, ipNet, err := net.ParseCIDR(podCidr)
 	if err != nil {
-		return err
+		return microerror.Mask(err)
 	}
 	prefix, _ := ipNet.Mask.Size()
 	if prefix > 18 {

--- a/pkg/aws/v1alpha3/awscluster/validate_awscluster.go
+++ b/pkg/aws/v1alpha3/awscluster/validate_awscluster.go
@@ -154,7 +154,7 @@ func (v *Validator) ValidateUpdate(request *admissionv1.AdmissionRequest) (bool,
 }
 
 func (v *Validator) Cilium(awsCluster infrastructurev1alpha3.AWSCluster) error {
-	podCidr, ok := awsCluster.Annotations["cilium.giantswarm.io/pod-cidr"]
+	podCidr, ok := awsCluster.GetAnnotations()[annotation.CiliumPodCidr]
 	if !ok {
 		return nil
 	}
@@ -166,7 +166,7 @@ func (v *Validator) Cilium(awsCluster infrastructurev1alpha3.AWSCluster) error {
 	prefix, _ := ipNet.Mask.Size()
 	if prefix > 18 {
 		return microerror.Maskf(notAllowedError,
-			fmt.Sprint("The CIDR from annotation `cilium.giantswarm.io/pod-cidr` is not valid, please specify a network mask which is at least `/18` or bigger, e.g. `10.0.0.0/15`"),
+			fmt.Sprintf("The CIDR from annotation `%s` is not valid, please specify a network mask which is at least `/18` or bigger, e.g. `10.0.0.0/15`", annotation.CiliumPodCidr),
 		)
 	}
 

--- a/pkg/aws/v1alpha3/awscluster/validate_awscluster.go
+++ b/pkg/aws/v1alpha3/awscluster/validate_awscluster.go
@@ -3,6 +3,8 @@ package awscluster
 import (
 	"context"
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 
 	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"
@@ -111,6 +113,11 @@ func (v *Validator) ValidateUpdate(request *admissionv1.AdmissionRequest) (bool,
 		return false, microerror.Maskf(parsingFailedError, "unable to parse awscluster: %v", err)
 	}
 
+	err = v.Cilium(awsCluster)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
 	err = aws.ValidateOrganizationLabelContainsExistingOrganization(context.Background(), v.k8sClient.CtrlClient(), &awsCluster)
 	if err != nil {
 		return false, microerror.Mask(err)
@@ -145,6 +152,29 @@ func (v *Validator) ValidateUpdate(request *admissionv1.AdmissionRequest) (bool,
 	}
 
 	return true, nil
+}
+
+func (v *Validator) Cilium(awsCluster infrastructurev1alpha3.AWSCluster) error {
+	podCidr, ok := awsCluster.Annotations["cilium.giantswarm.io/pod-cidr"]
+	if !ok {
+		return nil
+	}
+
+	_, ipNet, err := net.ParseCIDR(podCidr)
+	if err != nil {
+		return err
+	}
+	mask, err := strconv.Atoi(ipNet.Mask.String())
+	if err != nil {
+		return err
+	}
+	if mask > 18 {
+		return microerror.Maskf(notAllowedError,
+			fmt.Sprint("The CIDR from annotation `cilium.giantswarm.io/pod-cidr` is not valid, please specify a network mask which is at least `/18` or bigger, e.g. `10.0.0.0/15`"),
+		)
+	}
+
+	return nil
 }
 
 func (v *Validator) AWSClusterAnnotationCNIMinimumIPTarget(awsCluster infrastructurev1alpha3.AWSCluster) error {

--- a/pkg/aws/v1alpha3/awscluster/validate_awscluster.go
+++ b/pkg/aws/v1alpha3/awscluster/validate_awscluster.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 
 	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"
@@ -164,11 +163,8 @@ func (v *Validator) Cilium(awsCluster infrastructurev1alpha3.AWSCluster) error {
 	if err != nil {
 		return err
 	}
-	mask, err := strconv.Atoi(ipNet.Mask.String())
-	if err != nil {
-		return err
-	}
-	if mask > 18 {
+	prefix, _ := ipNet.Mask.Size()
+	if prefix > 18 {
 		return microerror.Maskf(notAllowedError,
 			fmt.Sprint("The CIDR from annotation `cilium.giantswarm.io/pod-cidr` is not valid, please specify a network mask which is at least `/18` or bigger, e.g. `10.0.0.0/15`"),
 		)

--- a/pkg/aws/v1alpha3/awscluster/validate_awscluster_test.go
+++ b/pkg/aws/v1alpha3/awscluster/validate_awscluster_test.go
@@ -106,7 +106,7 @@ func TestCilium(t *testing.T) {
 
 			// set CNI prefix annotation
 			awsCluster.SetAnnotations(map[string]string{
-				"cilium.giantswarm.io/pod-cidr": tc.cidr,
+				annotation.CiliumPodCidr: tc.cidr,
 			})
 
 			err = validate.Cilium(*awsCluster)

--- a/pkg/aws/v1alpha3/awscluster/validate_awscluster_test.go
+++ b/pkg/aws/v1alpha3/awscluster/validate_awscluster_test.go
@@ -65,3 +65,54 @@ func TestAWSCNIPrefix(t *testing.T) {
 		})
 	}
 }
+
+func TestCilium(t *testing.T) {
+	testCases := []struct {
+		ctx  context.Context
+		name string
+
+		cidr string
+		err  error
+	}{
+		{
+			// CNI CIDR is not allowed.
+			name: "case 0",
+			ctx:  context.Background(),
+
+			cidr: "10.0.0.0/25",
+			err:  notAllowedError,
+		},
+		{
+			// CNI CIDR is allowed.
+			name: "case 1",
+			ctx:  context.Background(),
+
+			cidr: "10.0.0.0/8",
+			err:  nil,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+
+			fakeK8sClient := unittest.FakeK8sClient()
+			validate := &Validator{
+				k8sClient: fakeK8sClient,
+				logger:    microloggertest.New(),
+			}
+
+			// run admission request to default AWSCluster Pod CIDR
+			awsCluster := unittest.DefaultAWSCluster()
+
+			// set CNI prefix annotation
+			awsCluster.SetAnnotations(map[string]string{
+				"cilium.giantswarm.io/pod-cidr": tc.cidr,
+			})
+
+			err = validate.Cilium(*awsCluster)
+			if microerror.Cause(err) != tc.err {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/pkg/aws/v1alpha3/cluster/validate_cluster.go
+++ b/pkg/aws/v1alpha3/cluster/validate_cluster.go
@@ -161,7 +161,7 @@ func (v *Validator) Cilium(cluster *capi.Cluster) error {
 	_, ok := awsCluster.Annotations["cilium.giantswarm.io/pod-cidr"]
 	if !ok {
 		return microerror.Maskf(notAllowedError,
-			fmt.Sprint("The annotation `cilium.giantswarm.io/pod-cidr` has to be set on AWSCluster CR before upgrading to AWS release v18 or higher."),
+			"The annotation `cilium.giantswarm.io/pod-cidr` has to be set on AWSCluster CR before upgrading to AWS release v18 or higher.",
 		)
 	}
 

--- a/pkg/aws/v1alpha3/cluster/validate_cluster.go
+++ b/pkg/aws/v1alpha3/cluster/validate_cluster.go
@@ -158,10 +158,10 @@ func (v *Validator) Cilium(cluster *capi.Cluster) error {
 	if err != nil {
 		return err
 	}
-	_, ok := awsCluster.Annotations["cilium.giantswarm.io/pod-cidr"]
+	_, ok := awsCluster.Annotations[annotation.CiliumPodCidr]
 	if !ok {
 		return microerror.Maskf(notAllowedError,
-			"The annotation `cilium.giantswarm.io/pod-cidr` has to be set on AWSCluster CR before upgrading to AWS release v18 or higher.",
+			fmt.Sprintf("The annotation `%s` has to be set on AWSCluster CR before upgrading to AWS release v18 or higher.", annotation.CiliumPodCidr),
 		)
 	}
 

--- a/pkg/aws/v1alpha3/cluster/validate_cluster_test.go
+++ b/pkg/aws/v1alpha3/cluster/validate_cluster_test.go
@@ -522,29 +522,40 @@ func TestValidClusterStatus(t *testing.T) {
 
 func Test_CiliumReleaseIsValid(t *testing.T) {
 	testCases := []struct {
-		name       string
-		release    string
-		annotation map[string]string
+		name           string
+		currentRelease string
+		targetRelease  string
+		annotation     map[string]string
 
 		valid bool
 	}{
 		{
-			name:    "case 0: no cilium",
-			release: "17.4.0",
-			valid:   true,
+			name:           "case 0: no cilium",
+			currentRelease: "17.4.0",
+			targetRelease:  "17.4.1",
+			valid:          true,
 		},
 		{
-			name:       "case 1: upgrade to cilium with pod cidr annotation",
-			release:    "18.0.0",
-			annotation: map[string]string{annotation.CiliumPodCidr: "10.0.0.0/8"},
+			name:           "case 1: upgrade to cilium with pod cidr annotation",
+			currentRelease: "17.4.1",
+			targetRelease:  "18.0.0",
+			annotation:     map[string]string{annotation.CiliumPodCidr: "10.0.0.0/8"},
 
 			valid: true,
 		},
 		{
-			name:    "case 2: upgrade to cilium without pod cidr annotation",
-			release: "18.0.0",
+			name:           "case 2: upgrade to cilium without pod cidr annotation",
+			currentRelease: "17.4.1",
+			targetRelease:  "18.0.0",
 
 			valid: false,
+		},
+		{
+			name:           "case 3: upgrade to cilium without pod cidr annotation",
+			currentRelease: "18.0.0",
+			targetRelease:  "18.1.0",
+
+			valid: true,
 		},
 	}
 
@@ -557,7 +568,13 @@ func Test_CiliumReleaseIsValid(t *testing.T) {
 			cluster := unittest.DefaultCluster()
 			cluster.SetLabels(map[string]string{
 				label.Cluster:        unittest.DefaultClusterID,
-				label.ReleaseVersion: tc.release,
+				label.ReleaseVersion: tc.targetRelease,
+			})
+
+			oldCluster := unittest.DefaultCluster()
+			oldCluster.SetLabels(map[string]string{
+				label.Cluster:        unittest.DefaultClusterID,
+				label.ReleaseVersion: tc.currentRelease,
 			})
 
 			// create releases for testing
@@ -566,7 +583,13 @@ func Test_CiliumReleaseIsValid(t *testing.T) {
 					Name: "v17.4.0",
 				},
 				{
+					Name: "v17.4.1",
+				},
+				{
 					Name: "v18.0.0",
+				},
+				{
+					Name: "v18.1.0",
 				},
 			}
 			for _, r := range releases {
@@ -580,7 +603,7 @@ func Test_CiliumReleaseIsValid(t *testing.T) {
 			awsCluster := unittest.DefaultAWSCluster()
 			awsCluster.SetAnnotations(tc.annotation)
 			awsCluster.SetLabels(map[string]string{
-				label.ReleaseVersion: "v" + tc.release,
+				label.ReleaseVersion: "v" + tc.currentRelease,
 				label.Cluster:        unittest.DefaultClusterID,
 			})
 			err := v.k8sClient.CtrlClient().Create(context.Background(), awsCluster)
@@ -588,7 +611,7 @@ func Test_CiliumReleaseIsValid(t *testing.T) {
 				t.Fatal(err)
 			}
 			// check if the result is as expected
-			err = v.Cilium(cluster)
+			err = v.Cilium(oldCluster, cluster)
 			if tc.valid && err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}

--- a/pkg/aws/v1alpha3/cluster/validate_cluster_test.go
+++ b/pkg/aws/v1alpha3/cluster/validate_cluster_test.go
@@ -519,3 +519,82 @@ func TestValidClusterStatus(t *testing.T) {
 		})
 	}
 }
+
+func Test_CiliumReleaseIsValid(t *testing.T) {
+	testCases := []struct {
+		name       string
+		release    string
+		annotation map[string]string
+
+		valid bool
+	}{
+		{
+			name:    "case 0: no cilium",
+			release: "17.4.0",
+			valid:   true,
+		},
+		{
+			name:       "case 1: upgrade to cilium with pod cidr annotation",
+			release:    "18.0.0",
+			annotation: map[string]string{"cilium.giantswarm.io/pod-cidr": "10.0.0.0/8"},
+
+			valid: true,
+		},
+		{
+			name:    "case 2: upgrade to cilium without pod cidr annotation",
+			release: "18.0.0",
+
+			valid: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			v := &Validator{
+				k8sClient: unittest.FakeK8sClient(),
+				logger:    microloggertest.New(),
+			}
+			cluster := unittest.DefaultCluster()
+			cluster.SetLabels(map[string]string{
+				label.Cluster:        unittest.DefaultClusterID,
+				label.ReleaseVersion: tc.release,
+			})
+
+			// create releases for testing
+			releases := []unittest.ReleaseData{
+				{
+					Name: "v17.4.0",
+				},
+				{
+					Name: "v18.0.0",
+				},
+			}
+			for _, r := range releases {
+				release := unittest.DefaultRelease()
+				release.SetName(r.Name)
+				err := v.k8sClient.CtrlClient().Create(context.Background(), &release)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			awsCluster := unittest.DefaultAWSCluster()
+			awsCluster.SetAnnotations(tc.annotation)
+			awsCluster.SetLabels(map[string]string{
+				label.ReleaseVersion: "v" + tc.release,
+				label.Cluster:        unittest.DefaultClusterID,
+			})
+			err := v.k8sClient.CtrlClient().Create(context.Background(), awsCluster)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// check if the result is as expected
+			err = v.Cilium(cluster)
+			if tc.valid && err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+			if !tc.valid && err == nil {
+				t.Fatalf("expected error but returned %v", err)
+			}
+		})
+	}
+}

--- a/pkg/aws/v1alpha3/cluster/validate_cluster_test.go
+++ b/pkg/aws/v1alpha3/cluster/validate_cluster_test.go
@@ -536,7 +536,7 @@ func Test_CiliumReleaseIsValid(t *testing.T) {
 		{
 			name:       "case 1: upgrade to cilium with pod cidr annotation",
 			release:    "18.0.0",
-			annotation: map[string]string{"cilium.giantswarm.io/pod-cidr": "10.0.0.0/8"},
+			annotation: map[string]string{annotation.CiliumPodCidr: "10.0.0.0/8"},
 
 			valid: true,
 		},

--- a/pkg/aws/v1alpha3/common.go
+++ b/pkg/aws/v1alpha3/common.go
@@ -33,7 +33,7 @@ const (
 	FirstV1Alpha3Release = "16.0.0"
 
 	// FirstCiliumRelease is the first Cilium CNI GS release
-	FirstCiliumRelease = "18.0.0"
+	FirstCiliumRelease = "18.0.0-alpha1"
 
 	// FirstOrgNamespaceRelease is the first GS release that creates Clusters in Org Namespaces by default
 	FirstOrgNamespaceRelease = "16.0.0"

--- a/pkg/aws/v1alpha3/common.go
+++ b/pkg/aws/v1alpha3/common.go
@@ -112,6 +112,12 @@ func IsCiliumRelease(releaseVersion *semver.Version) bool {
 	return releaseVersion.GE(*V18Version)
 }
 
+// IsPreCiliumRelease returns whether a given releaseVersion is a prerelease of Cilium CNI integration
+func IsPreCiliumRelease(releaseVersion *semver.Version) bool {
+	V18Version, _ := semver.New(FirstCiliumRelease)
+	return releaseVersion.LT(*V18Version)
+}
+
 // IsOrgNamespaceVersion returns whether a given releaseVersion creates clusters in org namespaces by default
 func IsOrgNamespaceVersion(releaseVersion *semver.Version) bool {
 	OrgNamespaceVersion, _ := semver.New(FirstOrgNamespaceRelease)

--- a/pkg/aws/v1alpha3/common.go
+++ b/pkg/aws/v1alpha3/common.go
@@ -32,6 +32,9 @@ const (
 	// FirstV1Alpha3Release is the first GS release for v1alpha3 GiantSwarm AWS CR's
 	FirstV1Alpha3Release = "16.0.0"
 
+	// FirstCiliumRelease is the first Cilium CNI GS release
+	FirstCiliumRelease = "18.0.0"
+
 	// FirstOrgNamespaceRelease is the first GS release that creates Clusters in Org Namespaces by default
 	FirstOrgNamespaceRelease = "16.0.0"
 
@@ -101,6 +104,12 @@ func IsHAVersion(releaseVersion *semver.Version) bool {
 func IsV1Alpha3Ready(releaseVersion *semver.Version) bool {
 	V1Alpha3Version, _ := semver.New(FirstV1Alpha3Release)
 	return releaseVersion.GE(*V1Alpha3Version)
+}
+
+// IsCiliumRelease returns whether a given releaseVersion is release with Cilium CNI
+func IsCiliumRelease(releaseVersion *semver.Version) bool {
+	V18Version, _ := semver.New(FirstCiliumRelease)
+	return releaseVersion.GE(*V18Version)
 }
 
 // IsOrgNamespaceVersion returns whether a given releaseVersion creates clusters in org namespaces by default


### PR DESCRIPTION
Issue: https://github.com/giantswarm/giantswarm/issues/23061

- [Cluster CR Validate Update] we block upgrading from v17 to v18 if the cilium.giantswarm.io/pod-cidr annotation is missing in the AWSCluster CR.
- [AWSCluster CR validate update] we check the cilium.giantswarm.io/pod-cidr annotation is a syntactically valid cidr (10.0.0.0/15). Subnet mask <= 18