### PR TITLE
Checking CIDRs do not intersect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Validate `cilium.giantswarm.io/pod-cidr` annotation does not intersect with current CIDR's.
 - Validate `cilium.giantswarm.io/pod-cidr` annotation is present and valid while upgrading from v17 to v18.
 
 ## [4.1.0] - 2022-07-22

--- a/pkg/aws/v1alpha3/awscluster/validate_awscluster.go
+++ b/pkg/aws/v1alpha3/awscluster/validate_awscluster.go
@@ -21,6 +21,9 @@ import (
 type Validator struct {
 	k8sClient k8sclient.Interface
 	logger    micrologger.Logger
+
+	podCIDRBlock  string
+	ipamCidrBlock string
 }
 
 func NewValidator(config config.Config) (*Validator, error) {
@@ -34,6 +37,9 @@ func NewValidator(config config.Config) (*Validator, error) {
 	v := &Validator{
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,
+
+		podCIDRBlock:  fmt.Sprintf("%s/%s", config.PodSubnet, config.PodCIDR),
+		ipamCidrBlock: config.IPAMNetworkCIDR,
 	}
 
 	return v, nil
@@ -159,15 +165,32 @@ func (v *Validator) Cilium(awsCluster infrastructurev1alpha3.AWSCluster) error {
 		return nil
 	}
 
-	_, ipNet, err := net.ParseCIDR(podCidr)
+	_, ciliumIPNet, err := net.ParseCIDR(podCidr)
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	prefix, _ := ipNet.Mask.Size()
+	prefix, _ := ciliumIPNet.Mask.Size()
 	if prefix > 18 {
 		return microerror.Maskf(notAllowedError,
 			fmt.Sprintf("The CIDR from annotation `%s` is not valid, please specify a network mask which is at least `/18` or bigger, e.g. `10.0.0.0/15`", annotation.CiliumPodCidr),
 		)
+	}
+
+	_, awsPodIPNet, err := net.ParseCIDR(v.podCIDRBlock)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	_, ipamIPNet, err := net.ParseCIDR(v.ipamCidrBlock)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if intersect(ciliumIPNet, awsPodIPNet) || intersect(ciliumIPNet, ipamIPNet) {
+		return microerror.Maskf(notAllowedError,
+			fmt.Sprintf("The CIDR from annotation `%s` intersects with the current CIDRs `%s`, `%s`, please specify a different CIDR", annotation.CiliumPodCidr, v.podCIDRBlock, v.ipamCidrBlock),
+		)
+
 	}
 
 	return nil
@@ -270,4 +293,8 @@ func (v *Validator) Log(keyVals ...interface{}) {
 
 func (v *Validator) Resource() string {
 	return "awscluster"
+}
+
+func intersect(n1, n2 *net.IPNet) bool {
+	return n2.Contains(n1.IP) || n1.Contains(n2.IP)
 }

--- a/pkg/aws/v1alpha3/awscluster/validate_awscluster_test.go
+++ b/pkg/aws/v1alpha3/awscluster/validate_awscluster_test.go
@@ -117,7 +117,6 @@ func TestCilium(t *testing.T) {
 				logger:    microloggertest.New(),
 
 				ipamCidrBlock: tc.ipamCidrBlock,
-				podCIDRBlock:  tc.podCidrBlock,
 			}
 
 			// run admission request to default AWSCluster Pod CIDR
@@ -127,6 +126,7 @@ func TestCilium(t *testing.T) {
 			awsCluster.SetAnnotations(map[string]string{
 				annotation.CiliumPodCidr: tc.ciliumCidr,
 			})
+			awsCluster.Spec.Provider.Pods.CIDRBlock = tc.podCidrBlock
 
 			err = validate.Cilium(*awsCluster)
 			if microerror.Cause(err) != tc.err {

--- a/pkg/aws/v1alpha3/awscluster/validate_awscluster_test.go
+++ b/pkg/aws/v1alpha3/awscluster/validate_awscluster_test.go
@@ -97,7 +97,7 @@ func TestCilium(t *testing.T) {
 			err:           notAllowedError,
 		},
 		{
-			// CNI CIDR is not allowed, overlapping CIDR's.
+			// CNI CIDR is allowed, no overlapping CIDR's.
 			name: "case 1",
 			ctx:  context.Background(),
 


### PR DESCRIPTION
Issue: https://github.com/giantswarm/giantswarm/issues/23061

aws-admission-controller contains the default CIDR's from the installation, added via ENV.

Example:
```
DEFAULT_IPAM_NETWORKCIDR:             10.5.0.0/16  => ipamCidrBlock
```
```
DEFAULT_AWS_POD_CIDR:                 16
        +
DEFAULT_AWS_POD_SUBNET:               100.65.0.0   => podCIDRBlock

``` 

Those are stored in the validator config and it will be checked if there's a intersection with the new cilium CIDR. 