### PR TITLE
Default `cilium.giantswarm.io/ipam-mode` annotation on `Cluster` CR d…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add validation for `cilium.giantswarm.io/ipam-mode` annotation on `Cluster` CR creation.
+- Default `cilium.giantswarm.io/ipam-mode` annotation on `Cluster` CR during creation of v19 cluster.
 
 ## [4.8.1] - 2023-06-07
 

--- a/pkg/aws/v1alpha3/cluster/mutate_cilium_ipam_mode_default_test.go
+++ b/pkg/aws/v1alpha3/cluster/mutate_cilium_ipam_mode_default_test.go
@@ -1,0 +1,106 @@
+package cluster
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/giantswarm/k8smetadata/pkg/annotation"
+	"github.com/giantswarm/micrologger/microloggertest"
+	releasev1alpha1 "github.com/giantswarm/release-operator/v4/api/v1alpha1"
+
+	"github.com/giantswarm/aws-admission-controller/v4/pkg/label"
+	"github.com/giantswarm/aws-admission-controller/v4/pkg/mutator"
+	unittest "github.com/giantswarm/aws-admission-controller/v4/pkg/unittest/v1alpha3"
+)
+
+func TestDefaultCiliumIpamMode(t *testing.T) {
+	testCases := []struct {
+		ctx  context.Context
+		name string
+
+		release          string
+		currentValue     string
+		expectedIpamMode string
+	}{
+		{
+			name: "case 0: pre-cilium release",
+			ctx:  context.Background(),
+
+			release:          "18.0.0",
+			expectedIpamMode: "",
+		},
+		{
+			name: "case 1: cilium release, no previous value",
+			ctx:  context.Background(),
+
+			release:          "19.0.0",
+			currentValue:     "",
+			expectedIpamMode: "kubernetes",
+		},
+		{
+			name: "case 2: cilium release, existing value",
+			ctx:  context.Background(),
+
+			release:          "19.0.0",
+			currentValue:     "eni",
+			expectedIpamMode: "",
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+
+			fakeK8sClient := unittest.FakeK8sClient()
+			mutate := &Mutator{
+				k8sClient:            fakeK8sClient,
+				logger:               microloggertest.New(),
+				defaultAWSCNIPodCidr: "10.10.0.0/16",
+				defaultCiliumPodCidr: "192.168.0.0/16",
+			}
+			// create releases
+			releases := []releasev1alpha1.Release{
+				unittest.NamedRelease("v18.0.0"),
+				unittest.NamedRelease("v19.0.0"),
+			}
+			for _, release := range releases {
+				err = fakeK8sClient.CtrlClient().Create(tc.ctx, &release) // nolint:gosec
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// create old and new objects
+			cluster := unittest.DefaultCluster()
+			cluster.SetLabels(map[string]string{label.Cluster: cluster.Labels[label.Cluster], label.Release: tc.release})
+
+			if tc.currentValue != "" {
+				if cluster.Annotations == nil {
+					cluster.Annotations = make(map[string]string, 0)
+				}
+				cluster.Annotations[annotation.CiliumIpamModeAnnotation] = tc.currentValue
+			}
+
+			// run mutate function to default cluster operator label
+			var patch []mutator.PatchOperation
+			release := semver.MustParse(tc.release)
+
+			patch = mutate.DefaultCiliumIpamMode(*cluster, &release)
+
+			// parse patches
+			var ipamMode string
+			for _, p := range patch {
+				if p.Path == "/metadata/annotations" {
+					annotations := p.Value.(map[string]string)
+
+					ipamMode = annotations[annotation.CiliumIpamModeAnnotation]
+				}
+			}
+			// check if the ipam mode is as expected
+			if tc.expectedIpamMode != ipamMode {
+				t.Fatalf("%s: expected %#q, got %#q", tc.name, tc.expectedIpamMode, ipamMode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…uring creation of v19 cluster.

towards: https://github.com/giantswarm/giantswarm/issues/26975

on cluster CR creation, default the ipam mode annotation to `kubernets` if not set.