### PR TITLE
Check validity of `cilium.giantswarm.io/ipam-mode` on `Cluster` CR up…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Check validity of `cilium.giantswarm.io/ipam-mode` on `Cluster` CR update as well.
+
 ## [4.9.0] - 2023-06-28
 
 ### Added

--- a/pkg/aws/v1alpha3/cluster/validate_cluster.go
+++ b/pkg/aws/v1alpha3/cluster/validate_cluster.go
@@ -167,6 +167,11 @@ func (v *Validator) ValidateUpdate(request *admissionv1.AdmissionRequest) (bool,
 		}
 	}
 
+	err = v.ValidateCiliumIpamMode(cluster)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
 	err = v.ValidateCiliumIpamModeUnchanged(oldCluster, cluster)
 	if err != nil {
 		return false, microerror.Mask(err)


### PR DESCRIPTION
…date as well.

it's currently possible to update value when cluster is <19.0.0 to a bogus value