### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-
 - Fix the requests duration metrics exposed by the controller, as the duration was always 0. 
-
 ### Added
-
 - Add `global.podSecurityStandards.enforced` value for PSS migration.
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
 
 ## [4.12.0] - 2023-08-23
 
 ### Changed
 
-- Don't change pod CIDR during upgrade from v18 to v19 if eni ipam mode is enabled. 
+- Don't change pod CIDR during upgrade from v18 to v19 if eni ipam mode is enabled.
 
 ## [4.11.0] - 2023-07-14
 

--- a/helm/aws-admission-controller/values.yaml
+++ b/helm/aws-admission-controller/values.yaml
@@ -22,7 +22,7 @@ workloadCluster:
       clusterIPRange: ""
 
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 image:
   name: "giantswarm/aws-admission-controller"
@@ -58,7 +58,7 @@ securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
-    - ALL
+      - ALL
 
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
